### PR TITLE
🐛 fix sidebar chevron from cutting off in smaller desktop screen 

### DIFF
--- a/src/layouts/DataVisualisationLayout.tsx
+++ b/src/layouts/DataVisualisationLayout.tsx
@@ -95,7 +95,7 @@ const DataVisualisationLayout: React.FC = () => {
         <div className="flex p-4">
           <button
             onClick={toggleSidebar}
-            className="absolute -left-6 mb-4 flex h-24 items-center justify-center rounded bg-imos-sea-blue p-2 text-white"
+            className="-left-6 mr-1 flex h-24 items-center justify-center rounded bg-imos-sea-blue p-2 text-white"
           >
             <ArrowIcon
               className={`h-5 w-5 transition-transform duration-300 ${isSidebarVisible ? 'rotate-90' : 'h-28 rotate-[270deg]'}`}


### PR DESCRIPTION
The sidebar chevron is cut off when the desktop width is less than 1500px. This PR fixes it.

Before:
![Screenshot 2024-11-29 at 11 59 42 am](https://github.com/user-attachments/assets/cccc9935-98e5-48a8-ba21-050c5505f2b4)

After:
![Screenshot 2024-11-29 at 11 59 11 am](https://github.com/user-attachments/assets/bd9b57c6-a2d6-478b-ab8d-830639820eeb)

Demo video:
https://github.com/user-attachments/assets/35fa1c80-1340-4c3e-bf72-797b1666c77b

