### PR TITLE
:bug: fix browser back button after clicking on argo points in map

### DIFF
--- a/src/components/Map/layers/ArgoAsProductLayer/ArgoAsProductLayerRenderer.tsx
+++ b/src/components/Map/layers/ArgoAsProductLayer/ArgoAsProductLayerRenderer.tsx
@@ -22,7 +22,8 @@ const ArgoAsProductLayerRenderer: React.FC<ArgoAsProductLayerRendererProps> = ({
   const { worldMeteorologicalOrgId: selectedWorldMeteorologicalOrgId } = useArgoStore(
     (state) => state.selectedArgoParams,
   );
-  const { ARGO_AS_PRODUCT_SELECTED_POINT_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID } = mapboxLayerIds;
+  const { ARGO_AS_PRODUCT_SELECTED_POINT_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID } =
+    mapboxLayerIds;
   const { ARGO_AS_PRODUCT_SOURCE_ID } = mapboxSourceIds;
 
   const [hoveredFeatureId, setHoveredFeatureId] = useState<number | string | null>(null);
@@ -144,20 +145,27 @@ const ArgoAsProductLayerRenderer: React.FC<ArgoAsProductLayerRendererProps> = ({
 
     if (!eventAdded.current) {
       eventAdded.current = true;
-      map.on('click', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseClick);
+      map.on('click', [ARGO_AS_PRODUCT_POINT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
       map.on('mousemove', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseMove);
       map.on('mouseleave', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseLeave);
     }
 
     return () => {
       if (map && eventAdded.current) {
-        map.off('click', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseClick);
+        map.off('click', [ARGO_AS_PRODUCT_POINT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
         map.off('mousemove', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseMove);
         map.off('mouseleave', ARGO_AS_PRODUCT_POINT_LAYER_ID, handleMouseLeave);
         eventAdded.current = false;
       }
     };
-  }, [map, handleMouseClick, handleMouseMove, handleMouseLeave, ARGO_AS_PRODUCT_POINT_LAYER_ID]);
+  }, [
+    map,
+    handleMouseClick,
+    handleMouseMove,
+    handleMouseLeave,
+    ARGO_AS_PRODUCT_POINT_LAYER_ID,
+    PRODUCT_REGION_BOX_LAYER_ID,
+  ]);
 
   useEffect(() => {
     if (!map || !isMiniMap) return;


### PR DESCRIPTION
This PR fixes a bug where the user had to click on the browser back button multiple times (5-10 times) to go back to the previous screen/page/url if they have clicked on an Argo point on the map.

Bug demo:
https://github.com/user-attachments/assets/5873c93b-3e77-4915-9736-7f1f23e43574

Fix demo:
https://github.com/user-attachments/assets/3c31c103-da93-4db2-9211-d0d57f86cdcd

