### PR TITLE
:lipstick: remove year from climatology date picker

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import arrowIcon from '@/assets/icons/arrow.svg';
 import calendarIcon from '@/assets/icons/calendar-icon.svg';
 import 'react-datepicker/dist/react-datepicker.css';
+import useProductCheck from '@/stores/product-store/hooks/useProductCheck';
 import { DatePickerProps } from './types/datePicker.types';
 
 const customInput = () => (
@@ -33,8 +34,12 @@ const DatePicker: React.FC<DatePickerProps> = ({
   isYearRange,
   isMobile,
 }) => {
+  const { isClimatology } = useProductCheck();
+
   const formattedDate = () => {
-    if (isMonthRange) {
+    if (isClimatology) {
+      return dayjs(selectedDate).format('MMM');
+    } else if (isMonthRange) {
       return dayjs(selectedDate).format('MMM YYYY');
     } else if (isWeekRange) {
       return dayjs(selectedDate).format('DD MMM HH:mm ');

--- a/src/stores/product-store/hooks/useProductCheck.ts
+++ b/src/stores/product-store/hooks/useProductCheck.ts
@@ -10,8 +10,9 @@ const useProductCheck = () => {
   const isRegionRequired = !productsWithoutRegion.includes(mainProductId);
   const isArgo = mainProductId === 'argo';
   const isCurrentMeters = mainProductId === 'currentMeters';
+  const isClimatology = mainProductId === 'climatology';
 
-  return { isRegionRequired, isArgo, isCurrentMeters };
+  return { isRegionRequired, isArgo, isCurrentMeters, isClimatology };
 };
 
 export default useProductCheck;


### PR DESCRIPTION
This PR removes the year from being displayed in the date picker only for Climatology.

![image](https://github.com/user-attachments/assets/660888ed-6a57-4dfb-8d8a-a9e152eca00e)
