### PR TITLE
:lipstick: use Adj SLA map image in Argo maps

### DIFF
--- a/src/components/Map/BasicMap.tsx
+++ b/src/components/Map/BasicMap.tsx
@@ -103,7 +103,7 @@ const BasicMap: React.FC<BasicMapProps> = ({
 
       {shouldShowCursorLocationPanel && <MouseCursorLocationPanel lat={cursorLngLat?.lat} lng={cursorLngLat?.lng} />}
 
-      {!isArgo && memoizedLayers.dataImageLayer}
+      {memoizedLayers.dataImageLayer}
       {!isArgo && memoizedLayers.regionPolygonLayer}
       {shouldShowArgoLayer && memoizedLayers.argoAsProductLayer}
       {shouldShowCurrentMetersLayer && memoizedLayers.currentMeterLayer}

--- a/src/components/Map/layers/DataImageLayer/DataImageLayer.tsx
+++ b/src/components/Map/layers/DataImageLayer/DataImageLayer.tsx
@@ -4,7 +4,9 @@ import DataImageLayerRenderer from './DataImageLayerRenderer';
 
 const DataImageLayer: React.FC = () => {
   const useProductId = useProductStore((state) => state.productParams.productId);
-  const urlPath = getEntryImagePathByProductId(useProductId);
+  // client requested to use adjusted SLA map for argo product, see https://github.com/aodn/backlog/issues/5575
+  const correctProductId = useProductId === 'argo' ? 'adjustedSeaLevelAnomaly-sla' : useProductId;
+  const urlPath = getEntryImagePathByProductId(correctProductId);
 
   if (!urlPath) {
     return null;


### PR DESCRIPTION
This PR implement changes to use the Adjusted SLA map image in Argo main map and mini map. This PR also covers the work for two issues - https://github.com/aodn/backlog/issues/6003 and https://github.com/aodn/backlog/issues/5575.

Before:
![image](https://github.com/user-attachments/assets/221cb0f5-ea66-4109-992c-22914b17f598)
![image](https://github.com/user-attachments/assets/0c29a050-5fc3-4807-81f9-37f7cb8658e3)

After:
![image](https://github.com/user-attachments/assets/d5f5dde4-b1b7-41df-a552-f86512c6fb04)
![image](https://github.com/user-attachments/assets/86d5a8db-ab49-4d61-a6b1-2e6c5b811454)
