### PR TITLE
🐛 product content missing white background

### DIFF
--- a/src/pages/DataView/data-image/DataImageWithArgoMap.tsx
+++ b/src/pages/DataView/data-image/DataImageWithArgoMap.tsx
@@ -97,7 +97,7 @@ const DataImageWithArgoMap: React.FC<DataImageWithArgoMapProps> = ({
   }
 
   return (
-    <div className="relative inline-block w-full">
+    <div className="relative inline-block h-full w-full bg-white">
       <img
         ref={imgRef}
         src={src}

--- a/src/pages/DataView/data-image/DataImageWithCurrentMetersMap.tsx
+++ b/src/pages/DataView/data-image/DataImageWithCurrentMetersMap.tsx
@@ -79,7 +79,7 @@ const DataImageWithCurrentMetersMap: React.FC<DataImageWithCurrentMetersMapProps
   };
 
   return (
-    <div className="relative inline-block w-full">
+    <div className="relative inline-block h-full w-full bg-white">
       <img
         ref={imgRef}
         src={src}

--- a/src/pages/DataView/data-image/DataImageWithTidalCurrentsMap.tsx
+++ b/src/pages/DataView/data-image/DataImageWithTidalCurrentsMap.tsx
@@ -79,7 +79,7 @@ const DataImageWithTidalCurrentsMap: React.FC<DataImageWithTidalCurrentsMapProps
   };
 
   return (
-    <div className="relative inline-block w-full">
+    <div className="relative inline-block h-full w-full bg-white">
       <img
         ref={imgRef}
         src={src}

--- a/src/pages/DataView/product-content/ProductContent.tsx
+++ b/src/pages/DataView/product-content/ProductContent.tsx
@@ -191,16 +191,18 @@ const ProductContent: React.FC = () => {
 
   if (showVideo) {
     return (
-      <video
-        onClick={handlePopup}
-        className="max-h-[80vh] w-full select-none object-contain"
-        src={buildMediaUrl()}
-        controls
-        onError={handleError}
-      >
-        <track default kind="captions" srcLang="en" />
-        Your browser does not support the video tag.
-      </video>
+      <div className="h-full bg-white">
+        <video
+          onClick={handlePopup}
+          className="max-h-[80vh] w-full select-none object-contain"
+          src={buildMediaUrl()}
+          controls
+          onError={handleError}
+        >
+          <track default kind="captions" srcLang="en" />
+          Your browser does not support the video tag.
+        </video>
+      </div>
     );
   }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/82b2e5e6-8fa5-4792-acb1-b54c5de76405)

After:
![image](https://github.com/user-attachments/assets/0d25c781-a05a-4622-bcdc-d81728501231)
