### PR TITLE
🐛 fix landing page map carousel auto cycle 

### DIFF
--- a/src/components/Map/layers/RegionPolygonLayer.tsx
+++ b/src/components/Map/layers/RegionPolygonLayer.tsx
@@ -66,13 +66,14 @@ const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) =>
       if (baseProductPath === 'eac-mooring-array') {
         mapFitBounds(region.coords, 20);
       }
-      // so that Antarctica region is visible in map
-      else if (baseProductPath === 'seal-ctd/tracks' && !isMiniMap) {
+
+      // so that Antarctica region is visible
+      if (baseProductPath === 'seal-ctd/tracks' && !isMiniMap) {
         mapFitBounds(region.coords, 200);
       }
 
-      // default to selected region
-      else {
+      // focus on region only when in minimap, otherwise the map carousel in landing page breaks the auto cycle
+      if (isMiniMap) {
         mapFitBounds(region.coords);
       }
     }


### PR DESCRIPTION
The changes in [PR 193](https://github.com/aodn/ocean-current-frontend/pull/193/files#diff-b2912eb6e7acc1a8ed16b500022273b40e0ace39501bf04c4fc76e6b192bc79cR75-R76) broke the auto cycle feature of the Map Carousel in the landing page. The fix is to only fit the bounds when in mini map view.