### PR TITLE
:zap: chore(usedatelist): disable usequery retry policy

### DIFF
--- a/src/hooks/useDateList/useDateList.ts
+++ b/src/hooks/useDateList/useDateList.ts
@@ -50,7 +50,7 @@ const useDateList = (productId: ProductID) => {
 
   const regionScope = useProductStore((state) => state.productParams.regionScope);
   const regionCodeFromStore = useProductStore((state) => state.productParams.regionCode);
-  const region = regionCodeFromStore!;
+  const region = regionCodeFromStore;
   const metaData = useArgoStore((state) => state);
   const wmoId = metaData.selectedArgoParams.worldMeteorologicalOrgId;
 
@@ -68,8 +68,8 @@ const useDateList = (productId: ProductID) => {
 
   const standardQuery = useQuery({
     queryKey: ['dateList', productId, region],
-    queryFn: () => fetchImageListByProductIdAndRegion(productId, region),
-    enabled: shouldUseApi && !isArgo,
+    queryFn: () => fetchImageListByProductIdAndRegion(productId, region!),
+    enabled: shouldUseApi && !isArgo && Boolean(region),
     ...sharedQueryConfig,
   });
 


### PR DESCRIPTION
This pull request makes a small change to the `sharedQueryConfig` object in `src/hooks/useDateList/useDateList.ts` by adding the `retry: false` property to disable automatic retries for queries.

When no region is selected, we display a hard-coded list of dates. However, useQuery still stays in the isLoading state until all retry attempts finish, causing an unnecessary delay. By disabling the retry policy, we exit early and avoid waiting for redundant retries.
