### PR TITLE
:bug: fix SealCTD timeseries temperature and salinity data image

### DIFF
--- a/src/components/DatePicker/components/MultiFormatDatePicker.tsx
+++ b/src/components/DatePicker/components/MultiFormatDatePicker.tsx
@@ -105,6 +105,8 @@ const MultiFormatDatePicker: React.FC<MultiFormatDatePickerProps> = ({
         selected={selectedDate}
         onChange={handleDateChange}
         dateFormat="yyyy"
+        minDate={firstDate}
+        maxDate={lastDate}
         showYearPicker
         disabled={isDisabled}
       />

--- a/src/configs/query.ts
+++ b/src/configs/query.ts
@@ -1,0 +1,8 @@
+// Shared React Query configuration for consistent caching behavior
+export const sharedQueryConfig = {
+  staleTime: 6 * 60 * 60 * 1000, // 6 hours
+  gcTime: 12 * 60 * 60 * 1000, // 12 hours (previously cacheTime)
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  refetchOnMount: false,
+} as const;

--- a/src/hooks/useDateList/useDateList.ts
+++ b/src/hooks/useDateList/useDateList.ts
@@ -12,6 +12,7 @@ import useProductStore from '@/stores/product-store/productStore';
 import useArgoStore from '@/stores/argo-store/argoStore';
 import { buildProductImageUrl } from '@/utils/data-image-builder-utils/dataImgBuilder';
 import { RegionScope } from '@/constants/region';
+import { sharedQueryConfig } from '@/configs/query';
 import { generateDateRange } from './mockData';
 
 const extractDateFromFilename = (filename: string): string => {
@@ -69,14 +70,6 @@ const shouldUseSealCtdProcessor = (productId: ProductID, files: ImageFile[]): bo
 
   // Fallback heuristic by filename pattern (T_YYYY_pN.gif or S_YYYY[_YYYY]_pN.gif)
   return files.some(({ name }) => SEAL_CTD_FILENAME_REGEX.test(name));
-};
-
-const sharedQueryConfig = {
-  staleTime: 6 * 60 * 60 * 1000,
-  gcTime: 12 * 60 * 60 * 1000,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false,
 };
 
 const useDateList = (productId: ProductID) => {

--- a/src/pages/DataView/data-image/DataImageWithSealCtdGraphs.tsx
+++ b/src/pages/DataView/data-image/DataImageWithSealCtdGraphs.tsx
@@ -1,17 +1,20 @@
 import React, { useEffect, useRef, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { useNavigate } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
 import ErrorImage from '@/components/Shared/ErrorImage/ErrorImage';
 import { scaleImageMapAreas } from '@/utils/general-utils/general';
 import { ProductID, Product } from '@/types/product';
 import { MapImageAreas } from '@/types/dataImage';
-import { buildSealCtdGraphImageUrl } from '@/utils/data-image-builder-utils/dataImgBuilder';
-import { getSealCtdGraphTags, validateSealCtdImgUrl } from '@/services/sealCtd';
+import { getSealCtdGraphTags } from '@/services/sealCtd';
 import { imageBaseUrl } from '@/configs/image';
 import { Loading } from '@/components/Shared';
 import { parseSealCtdGraphTagData } from '@/utils/seal-ctd-utils/sealStdTags';
 import { DateFormat } from '@/types/date';
 import { ProductPath } from '@/types/router';
+import { fetchImageListByProductIdAndRegion } from '@/services/imageList';
+import { ImageListResponse } from '@/types/imageList';
+import { sharedQueryConfig } from '@/configs/query';
 
 type DataImageWithSealCtdGraphsProps = {
   mainProduct: Product | null;
@@ -25,16 +28,22 @@ type SealGraphData = {
   areas: MapImageAreas[];
 };
 
-// at the moment there's a max of 6 pages of graphs, we can remove these once API is implemented
-const maxPages = 6;
-const getAllImageUrls = (region: string, date: Dayjs, subProductKey: ProductID) => {
-  const imgUrls = [];
+const getImageUrlsFromDateList = (files: { name: string }[], region: string, productId: ProductID, year: string) => {
+  const prefix = productId === 'sealCtd-timeseriesTemperature' ? 'T_' : 'S_';
+  const formattedRegion = region === 'GAB-Seal' ? 'GAB' : region;
 
-  for (let i = 0; i < maxPages; i++) {
-    const imgUrl = buildSealCtdGraphImageUrl(region, date, subProductKey, i);
-    imgUrls.push(imgUrl);
-  }
-  return imgUrls;
+  return files
+    .filter((file) => {
+      if (!file.name.startsWith(prefix) || !file.name.endsWith('.gif')) {
+        return false;
+      }
+
+      // Match patterns like T_2014_p0.gif, S_2023_2024_p0.gif, etc.
+      // The year should match the first year in the filename
+      const yearMatch = file.name.match(new RegExp(`^${prefix}(\\d{4})`));
+      return yearMatch && yearMatch[1] === year;
+    })
+    .map((file) => `/AATAMS/${formattedRegion}/timeseries/${file.name}`);
 };
 
 const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
@@ -48,35 +57,38 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
   const [imgLoadError, setImgLoadError] = useState<string | null>(null);
   const [imgData, setImgData] = useState<SealGraphData[]>([]);
   const [imgUrls, setImgUrls] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [hasImgLoaded, setHasImgLoaded] = useState<boolean>(false);
 
-  // generate and validate image urls
+  const imageListQuery = useQuery({
+    queryKey: ['dateList', productId, region],
+    queryFn: () => fetchImageListByProductIdAndRegion(productId, region!),
+    enabled: Boolean(region),
+    ...sharedQueryConfig,
+  });
+
   useEffect(() => {
-    const getValidImageUrls = async () => {
-      setHasImgLoaded(false);
-      setIsLoading(true);
-      const allImgUrls = getAllImageUrls(region, date, productId);
-      const validImgUrls = await validateSealCtdImgUrl(allImgUrls);
+    if (!imageListQuery.data) {
+      setImgUrls([]);
+      return;
+    }
 
-      if (validImgUrls.length < 1) {
-        setImgLoadError('No image available.');
-      } else {
-        setImgLoadError(null);
-        setImgUrls(validImgUrls);
-      }
-      setIsLoading(false);
-    };
-    getValidImageUrls();
-  }, [date, productId, region]);
+    const files = (imageListQuery.data.data as ImageListResponse[])[0]?.files || [];
+    const currentYear = date.format('YYYY');
+    const imageUrls = getImageUrlsFromDateList(files, region, productId, currentYear);
 
-  // fetch image tags if there are valid image urls
+    if (imageUrls.length < 1) {
+      setImgLoadError('No image available.');
+    } else {
+      setImgLoadError(null);
+      setImgUrls(imageUrls);
+    }
+  }, [imageListQuery.data, region, productId, date]);
+
   useEffect(() => {
     if (imgUrls.length < 1) return;
 
     const fetchData = async () => {
       setHasImgLoaded(false);
-      setIsLoading(true);
       const tempArr = await Promise.all(
         imgUrls.map(async (url) => {
           const imgTags = await getSealCtdGraphTags(url);
@@ -88,7 +100,6 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
       );
 
       setImgData(tempArr);
-      setIsLoading(false);
     };
 
     fetchData();
@@ -98,8 +109,12 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
     return <ErrorImage productId={mainProduct!.key} date={dayjs(date)} />;
   }
 
-  if (isLoading) {
+  if (imageListQuery.isLoading) {
     return <Loading />;
+  }
+
+  if (imageListQuery.error) {
+    return <ErrorImage productId={mainProduct!.key} date={dayjs(date)} />;
   }
 
   const handleImageLoad = () => {
@@ -132,10 +147,14 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
 
   return (
     <div className="relative inline-block w-full">
-      {imgData.map(({ url, areas }) => {
-        const pageNum = url.split('_')[2].replace('.gif', '');
+      {imgData.map(({ url, areas }, index) => {
+        // Extract page number from the filename (e.g., "T_2023_p0.gif" -> "0")
+        const filename = url.split('/').pop() || '';
+        const pageMatch = filename.match(/_p(\d+)\.gif$/);
+        const pageNum = pageMatch ? pageMatch[1] : index.toString();
+
         return (
-          <>
+          <div key={url}>
             <img
               id={pageNum}
               ref={imgRef}
@@ -173,7 +192,7 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
                   ))}
               </map>
             )}
-          </>
+          </div>
         );
       })}
     </div>

--- a/src/pages/DataView/data-image/DataImageWithSealCtdGraphs.tsx
+++ b/src/pages/DataView/data-image/DataImageWithSealCtdGraphs.tsx
@@ -13,7 +13,6 @@ import { parseSealCtdGraphTagData } from '@/utils/seal-ctd-utils/sealStdTags';
 import { DateFormat } from '@/types/date';
 import { ProductPath } from '@/types/router';
 import { fetchImageListByProductIdAndRegion } from '@/services/imageList';
-import { ImageListResponse } from '@/types/imageList';
 import { sharedQueryConfig } from '@/configs/query';
 
 type DataImageWithSealCtdGraphsProps = {
@@ -28,9 +27,16 @@ type SealGraphData = {
   areas: MapImageAreas[];
 };
 
+const hasFilesWithNames = (value: unknown): value is { files: { name: string }[] } => {
+  if (typeof value !== 'object' || value === null) return false;
+  const files = (value as { files?: unknown }).files;
+  return Array.isArray(files) && files.every((f) => f && typeof (f as { name?: unknown }).name === 'string');
+};
+
 const getImageUrlsFromDateList = (files: { name: string }[], region: string, productId: ProductID, year: string) => {
   const prefix = productId === 'sealCtd-timeseriesTemperature' ? 'T_' : 'S_';
   const formattedRegion = region === 'GAB-Seal' ? 'GAB' : region;
+  const yearPrefixRegex = prefix === 'T_' ? /^T_(\d{4})/ : /^S_(\d{4})/;
 
   return files
     .filter((file) => {
@@ -40,7 +46,7 @@ const getImageUrlsFromDateList = (files: { name: string }[], region: string, pro
 
       // Match patterns like T_2014_p0.gif, S_2023_2024_p0.gif, etc.
       // The year should match the first year in the filename
-      const yearMatch = file.name.match(new RegExp(`^${prefix}(\\d{4})`));
+      const yearMatch = file.name.match(yearPrefixRegex);
       return yearMatch && yearMatch[1] === year;
     })
     .map((file) => `/AATAMS/${formattedRegion}/timeseries/${file.name}`);
@@ -72,7 +78,9 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
       return;
     }
 
-    const files = (imageListQuery.data.data as ImageListResponse[])[0]?.files || [];
+    const raw = imageListQuery.data?.data;
+    const first = Array.isArray(raw) ? raw[0] : undefined;
+    const files = first && hasFilesWithNames(first) ? first.files : [];
     const currentYear = date.format('YYYY');
     const imageUrls = getImageUrlsFromDateList(files, region, productId, currentYear);
 
@@ -154,7 +162,7 @@ const DataImageWithSealCtdGraphs: React.FC<DataImageWithSealCtdGraphsProps> = ({
         const pageNum = pageMatch ? pageMatch[1] : index.toString();
 
         return (
-          <div key={url}>
+          <div key={`${filename}-${pageNum}`}>
             <img
               id={pageNum}
               ref={imgRef}


### PR DESCRIPTION
- Replace hardcoded image URL generation with API-based file fetching
- Use same React Query cache as useDateList to eliminate duplicate API calls
- Extract shared query configuration to src/configs/query.ts for consistency
- Improve performance by leveraging cached data between date list and image  display