### PR TITLE
:recycle: replace click count with timestamp for map layer tracking

### DIFF
--- a/src/components/Map/controls/MapAnimationCompleteHandler.tsx
+++ b/src/components/Map/controls/MapAnimationCompleteHandler.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { MapMouseEvent, useMap } from 'react-map-gl/mapbox';
-import { notifyInteractiveLayerClick } from '@/stores/map-store/mapStore';
+import { updateInteractiveLayerClickTimestamp } from '@/stores/map-store/mapStore';
 import { mapboxLayerIds } from '@/constants/mapboxId';
 
 const { PRODUCT_REGION_BOX_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID, CURRENT_METERS_BOX_LAYER_ID } = mapboxLayerIds;
@@ -52,7 +52,7 @@ const MapAnimationCompleteHandler: React.FC<MapAnimationCompleteHandlerProps> = 
     const handleMoveEnd = () => {
       if (hasPendingAction.current) {
         hasPendingAction.current = false;
-        notifyInteractiveLayerClick();
+        updateInteractiveLayerClickTimestamp();
         if (onAnimationComplete) {
           onAnimationComplete();
         }

--- a/src/layouts/DataVisualisationLayout.tsx
+++ b/src/layouts/DataVisualisationLayout.tsx
@@ -47,7 +47,7 @@ const DataVisualisationLayout: React.FC = () => {
   const productId = useProductStore((state) => state.productParams.productId);
   const regionScope = useProductStore((state) => state.productParams.regionScope);
   const shouldShowProductOverMap = useShowProductOverMap();
-  const interactiveLayerClickCount = useMapStore((state) => state.interactiveLayerClickCount);
+  const interactiveLayerClickTimestamp = useMapStore((state) => state.interactiveLayerClickTimestamp);
   const toggleSidebar = () => setSidebarVisible((prev) => !prev);
 
   const urlType = useUrlType();
@@ -66,7 +66,7 @@ const DataVisualisationLayout: React.FC = () => {
 
   const { region: regionCodeFromUrl = 'Au', date } = useProductSearchParam();
   const previousDateRef = useRef<string | null>(null);
-  const previousClickCountRef = useRef<number>(0);
+  const previousClickTimestampRef = useRef<number>(0);
   const previousProductIdRef = useRef<string | null>(null);
 
   const parseeDateWithFormat = useCallback(
@@ -224,11 +224,11 @@ const DataVisualisationLayout: React.FC = () => {
 
   // Close map on mobile when interactive layer is clicked (after animations complete)
   useEffect(() => {
-    if (!isDesktopOrTablet && showMap && interactiveLayerClickCount !== previousClickCountRef.current) {
-      previousClickCountRef.current = interactiveLayerClickCount;
+    if (!isDesktopOrTablet && showMap && interactiveLayerClickTimestamp !== previousClickTimestampRef.current) {
+      previousClickTimestampRef.current = interactiveLayerClickTimestamp;
       setShowMap(false);
     }
-  }, [interactiveLayerClickCount, isDesktopOrTablet, showMap]);
+  }, [interactiveLayerClickTimestamp, isDesktopOrTablet, showMap]);
 
   if (!productId) {
     return <Loading />;

--- a/src/stores/map-store/map.types.ts
+++ b/src/stores/map-store/map.types.ts
@@ -2,7 +2,7 @@ import { ViewState } from 'react-map-gl/mapbox';
 
 export type State = {
   mapViewState: ViewState;
-  interactiveLayerClickCount: number;
+  interactiveLayerClickTimestamp: number;
 };
 
 export type Actions = {
@@ -14,7 +14,7 @@ export type Actions = {
     updateLongitude: (longitude: number) => void;
     updatePosition: (latitude: number, longitude: number) => void;
     updatePositionAndZoom: (latitude: number, longitude: number, zoom: number) => void;
-    notifyInteractiveLayerClick: () => void;
+    updateInteractiveLayerClickTimestamp: () => void;
     reset: (isMiniMap?: boolean) => void;
   };
 };

--- a/src/stores/map-store/mapStore.ts
+++ b/src/stores/map-store/mapStore.ts
@@ -6,7 +6,7 @@ import { State, Actions } from './map.types';
 const useMapStore = create<State & Actions>()(
   devtools((set) => ({
     ...initialMapViewState,
-    interactiveLayerClickCount: 0,
+    interactiveLayerClickTimestamp: 0,
     actions: {
       setMapViewState: (mapViewState) => {
         set((state) => ({ mapViewState: { ...state.mapViewState, ...mapViewState } }), false, 'setMapViewState');
@@ -40,12 +40,8 @@ const useMapStore = create<State & Actions>()(
           false,
           'updatePositionAndZoom',
         ),
-      notifyInteractiveLayerClick: () =>
-        set(
-          (state) => ({ interactiveLayerClickCount: state.interactiveLayerClickCount + 1 }),
-          false,
-          'notifyInteractiveLayerClick',
-        ),
+      updateInteractiveLayerClickTimestamp: () =>
+        set(() => ({ interactiveLayerClickTimestamp: Date.now() }), false, 'updateInteractiveLayerClickTimestamp'),
       reset: (isMiniMap = false) => {
         if (isMiniMap) {
           set((state) => ({ ...state, ...initialMiniMapViewState }), false, 'resetMapStore (mini map)');
@@ -65,7 +61,7 @@ export const {
   updateLatitude,
   updateLongitude,
   updatePosition,
-  notifyInteractiveLayerClick,
+  updateInteractiveLayerClickTimestamp,
   reset: resetMapStore,
 } = useMapStore.getState().actions;
 


### PR DESCRIPTION
Replace interactiveLayerClickCount with interactiveLayerClickTimestamp to prevent potential overflow issues and improve semantic clarity. The timestamp-based approach uses Date.now() instead of incrementing a counter, eliminating concerns about reaching MAX_SAFE_INTEGER while maintaining the same change-detection behavior.

Changes:
- Replace interactiveLayerClickCount with interactiveLayerClickTimestamp in map store state
- Change increment logic to use Date.now() for unique timestamps