### PR TITLE
:sparkles: implement layer priority system for map interactions

### DIFF
--- a/src/components/Map/controls/MapAnimationCompleteHandler.tsx
+++ b/src/components/Map/controls/MapAnimationCompleteHandler.tsx
@@ -3,7 +3,7 @@ import { MapMouseEvent, useMap } from 'react-map-gl/mapbox';
 import { updateInteractiveLayerClickTimestamp } from '@/stores/map-store/mapStore';
 import { mapboxLayerIds } from '@/constants/mapboxId';
 
-const { PRODUCT_REGION_BOX_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID, CURRENT_METERS_BOX_LAYER_ID } = mapboxLayerIds;
+const { PRODUCT_REGION_BOX_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID, CURRENT_METERS_PLOT_LAYER_ID } = mapboxLayerIds;
 
 interface MapAnimationCompleteHandlerProps {
   /**
@@ -35,7 +35,7 @@ const MapAnimationCompleteHandler: React.FC<MapAnimationCompleteHandlerProps> = 
       const existingLayers = [
         PRODUCT_REGION_BOX_LAYER_ID,
         ARGO_AS_PRODUCT_POINT_LAYER_ID,
-        CURRENT_METERS_BOX_LAYER_ID,
+        CURRENT_METERS_PLOT_LAYER_ID,
       ].filter((layerId) => map.getLayer(layerId));
 
       if (existingLayers.length === 0) return;

--- a/src/components/Map/layers/ArgoAsProductLayer.tsx
+++ b/src/components/Map/layers/ArgoAsProductLayer.tsx
@@ -7,6 +7,7 @@ import { ArgoProfile } from '@/types/argo';
 import { useQueryParams, useDeviceType } from '@/hooks';
 import { getBoundsFromCoordsArray } from '@/utils/geo-utils/geo';
 import { getPropertyFromMapFeatures, waitForMapAnimationAsync } from '../utils';
+import { shouldDeferToHigherPriorityLayer, hasFeatureAtPoint } from '../utils/layerPriority';
 import useArgoData from '../hooks/useArgoData';
 
 interface ArgoAsProductLayerProps {
@@ -45,6 +46,15 @@ const ArgoAsProductLayer: React.FC<ArgoAsProductLayerProps> = ({ isMiniMap, isAr
   const handleMouseClick = useCallback(
     async (e: MapMouseEvent) => {
       if (!map) return;
+
+      // Check if a higher-priority layer should handle this click
+      if (shouldDeferToHigherPriorityLayer(map, e, ARGO_AS_PRODUCT_POINT_LAYER_ID)) {
+        return;
+      }
+
+      if (!hasFeatureAtPoint(map, e, ARGO_AS_PRODUCT_POINT_LAYER_ID)) {
+        return;
+      }
 
       try {
         const clickedArgoParam = getPropertyFromMapFeatures<ArgoProfile>(map, e, ARGO_AS_PRODUCT_POINT_LAYER_ID, [
@@ -98,6 +108,11 @@ const ArgoAsProductLayer: React.FC<ArgoAsProductLayerProps> = ({ isMiniMap, isAr
   const handleMouseMove = useCallback(
     (e: MapMouseEvent) => {
       if (!map) return;
+
+      // Check if a higher-priority layer should handle this hover
+      if (shouldDeferToHigherPriorityLayer(map, e, ARGO_AS_PRODUCT_POINT_LAYER_ID)) {
+        return;
+      }
 
       const features = map.queryRenderedFeatures(e.point, {
         layers: [ARGO_AS_PRODUCT_POINT_LAYER_ID],

--- a/src/components/Map/layers/CurrentMetersDeploymentPlotsLayer.tsx
+++ b/src/components/Map/layers/CurrentMetersDeploymentPlotsLayer.tsx
@@ -9,6 +9,7 @@ import { currentMeterSYearOptionsData } from '@/data/current-meter/sidebarOption
 import { mooredInstrumentArrayPath } from '@/constants/currentMeters';
 import { SubProduct } from '@/types/product';
 import { getPropertyFromMapFeatures, waitForMapAnimationAsync } from '../utils';
+import { shouldDeferToHigherPriorityLayer, hasFeatureAtPoint } from '../utils/layerPriority';
 import getCurrentMetersDeploymentPlotsGeoJson from '../utils/getCurrentMetersDeploymentPlotsGeoJson';
 
 interface CurrentMetersDeploymentPlotsLayerProps {
@@ -20,7 +21,7 @@ const circleRadius = 6;
 const hoverCircleRadius = 8;
 const selectedCircleRadius = 12;
 const { CURRENT_METERS_DEPLOYMENT_PLOTS_SOURCE_ID } = mapboxSourceIds;
-const { CURRENT_METERS_BOX_LAYER_ID, CURRENT_METERS_SELECTED_BOX_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID } =
+const { CURRENT_METERS_PLOT_LAYER_ID, CURRENT_METERS_SELECTED_PLOT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID } =
   mapboxLayerIds;
 
 const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLayerProps> = ({
@@ -40,11 +41,21 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
     async (e: MapMouseEvent) => {
       if (!map) return;
 
+      // Check if a higher-priority layer should handle this click
+      if (shouldDeferToHigherPriorityLayer(map, e, CURRENT_METERS_PLOT_LAYER_ID)) {
+        return;
+      }
+
+      // Check if this layer has a feature at the click point
+      if (!hasFeatureAtPoint(map, e, CURRENT_METERS_PLOT_LAYER_ID)) {
+        return;
+      }
+
       try {
         const clickedPlot = getPropertyFromMapFeatures<CurrentMetersProfileProperties>(
           map,
           e,
-          CURRENT_METERS_BOX_LAYER_ID,
+          CURRENT_METERS_PLOT_LAYER_ID,
           ['title', 'region'],
         );
         const { title, region } = clickedPlot;
@@ -55,7 +66,7 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
         }
 
         const clickedFeature = map
-          .queryRenderedFeatures(e.point, { layers: [CURRENT_METERS_BOX_LAYER_ID] })
+          .queryRenderedFeatures(e.point, { layers: [CURRENT_METERS_PLOT_LAYER_ID] })
           .find((f) => f.properties?.title === title);
 
         if (clickedFeature && clickedFeature.geometry.type === 'Point') {
@@ -93,8 +104,13 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
     (e: MapMouseEvent) => {
       if (!map) return;
 
+      // Check if a higher-priority layer should handle this hover
+      if (shouldDeferToHigherPriorityLayer(map, e, CURRENT_METERS_PLOT_LAYER_ID)) {
+        return;
+      }
+
       const features = map.queryRenderedFeatures(e.point, {
-        layers: [CURRENT_METERS_BOX_LAYER_ID],
+        layers: [CURRENT_METERS_PLOT_LAYER_ID],
       });
 
       const isHoveredPlotFeature = features.length > 0 && features[0]?.id != null;
@@ -154,16 +170,16 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
 
     if (!eventAdded.current) {
       eventAdded.current = true;
-      map.on('click', [CURRENT_METERS_BOX_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
-      map.on('mousemove', CURRENT_METERS_BOX_LAYER_ID, handleMouseMove);
-      map.on('mouseleave', CURRENT_METERS_BOX_LAYER_ID, handleMouseLeave);
+      map.on('click', [CURRENT_METERS_PLOT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
+      map.on('mousemove', CURRENT_METERS_PLOT_LAYER_ID, handleMouseMove);
+      map.on('mouseleave', CURRENT_METERS_PLOT_LAYER_ID, handleMouseLeave);
     }
 
     return () => {
       if (map && eventAdded.current) {
-        map.off('click', [CURRENT_METERS_BOX_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
-        map.off('mousemove', CURRENT_METERS_BOX_LAYER_ID, handleMouseMove);
-        map.off('mouseleave', CURRENT_METERS_BOX_LAYER_ID, handleMouseLeave);
+        map.off('click', [CURRENT_METERS_PLOT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID], handleMouseClick);
+        map.off('mousemove', CURRENT_METERS_PLOT_LAYER_ID, handleMouseMove);
+        map.off('mouseleave', CURRENT_METERS_PLOT_LAYER_ID, handleMouseLeave);
         eventAdded.current = false;
       }
     };
@@ -190,7 +206,7 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
   return (
     <Source type="geojson" data={currentMetersMapPointsGeoJson} id={CURRENT_METERS_DEPLOYMENT_PLOTS_SOURCE_ID}>
       <Layer
-        id={CURRENT_METERS_SELECTED_BOX_LAYER_ID}
+        id={CURRENT_METERS_SELECTED_PLOT_LAYER_ID}
         type="circle"
         source={CURRENT_METERS_DEPLOYMENT_PLOTS_SOURCE_ID}
         paint={{
@@ -203,7 +219,7 @@ const CurrentMetersDeploymentPlotsLayer: React.FC<CurrentMetersDeploymentPlotsLa
         filter={['==', 'title', selectedDeploymentPlot]}
       />
       <Layer
-        id={CURRENT_METERS_BOX_LAYER_ID}
+        id={CURRENT_METERS_PLOT_LAYER_ID}
         type="circle"
         source={CURRENT_METERS_DEPLOYMENT_PLOTS_SOURCE_ID}
         paint={{

--- a/src/components/Map/layers/RegionPolygonLayer.tsx
+++ b/src/components/Map/layers/RegionPolygonLayer.tsx
@@ -18,18 +18,15 @@ import { RegionLatestDate } from '@/types/imageList';
 import { RegionScope } from '@/constants/region';
 import useRegionPolygons from '../hooks/useRegionPolygons';
 import { getPropertyFromMapFeatures, waitForMapAnimationAsync } from '../utils';
+import { shouldDeferToHigherPriorityLayer, hasFeatureAtPoint, shouldBlockRegionHover } from '../utils/layerPriority';
 
 interface RegionPolygonLayerProps {
   isMiniMap: boolean;
 }
 
 const { PRODUCT_REGION_BOX_SOURCE_ID } = mapboxSourceIds;
-const {
-  PRODUCT_REGION_BOX_LAYER_ID,
-  PRODUCT_REGION_NAME_LABEL_LAYER_ID,
-  PRODUCT_REGION_SELECTED_BOX_LAYER_ID,
-  ARGO_AS_PRODUCT_POINT_LAYER_ID,
-} = mapboxLayerIds;
+const { PRODUCT_REGION_BOX_LAYER_ID, PRODUCT_REGION_NAME_LABEL_LAYER_ID, PRODUCT_REGION_SELECTED_BOX_LAYER_ID } =
+  mapboxLayerIds;
 
 const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) => {
   const baseProductPath = useProductPath();
@@ -126,12 +123,18 @@ const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) =>
     (e: MapMouseEvent) => {
       if (!map) return;
 
-      const containsArgoLayer = map.getStyle()?.layers?.find((layer) => layer.id === ARGO_AS_PRODUCT_POINT_LAYER_ID);
-      const layersToCheck = containsArgoLayer
-        ? [PRODUCT_REGION_BOX_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID]
-        : [PRODUCT_REGION_BOX_LAYER_ID];
+      // Check if region hover should be blocked (e.g., by Argo points)
+      // Some layers like Argo points should block region highlighting,
+      // while others like CurrentMeter plots allow dual hover effect.
+      if (shouldBlockRegionHover(map, e)) {
+        setHoveredRegion('');
+        setHoveredId(null);
+        return;
+      }
+
+      // Check and highlight the region underneath
       const features = map.queryRenderedFeatures(e.point, {
-        layers: layersToCheck,
+        layers: [PRODUCT_REGION_BOX_LAYER_ID],
       });
 
       const isRegionHovered =
@@ -140,16 +143,10 @@ const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) =>
         features[0]?.geometry?.type === 'Polygon' &&
         features[0].id != null &&
         features[0].id != undefined;
+
       if (isRegionHovered) {
         setHoveredId(features[0].id!);
-      }
 
-      const checkIfArgoPoint = features.find((feature) => feature?.layer?.id === ARGO_AS_PRODUCT_POINT_LAYER_ID);
-
-      if (checkIfArgoPoint) {
-        setHoveredRegion('');
-        setHoveredId(null);
-      } else {
         const { name: regionName } = getPropertyFromMapFeatures<{
           name: string;
         }>(map, e, PRODUCT_REGION_BOX_LAYER_ID, ['name']);
@@ -157,6 +154,9 @@ const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) =>
         if (regionName) {
           setHoveredRegion(regionName);
         }
+      } else {
+        setHoveredRegion('');
+        setHoveredId(null);
       }
     },
     [map],
@@ -167,18 +167,19 @@ const RegionPolygonLayer: React.FC<RegionPolygonLayerProps> = ({ isMiniMap }) =>
       if (!hoveredRegion || !map || isLoadingLatestDates) {
         return;
       }
-      const containsArgoLayer = map.getStyle()?.layers?.find((layer) => layer.id === ARGO_AS_PRODUCT_POINT_LAYER_ID);
-      const layersToCheck = containsArgoLayer
-        ? [PRODUCT_REGION_BOX_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID]
-        : [PRODUCT_REGION_BOX_LAYER_ID];
-      const features = map.queryRenderedFeatures(e.point, {
-        layers: layersToCheck,
-      });
 
-      const hasArgoPoint = features.find((feature) => feature?.layer?.id === ARGO_AS_PRODUCT_POINT_LAYER_ID);
-      if (hasArgoPoint) {
+      // Check if a higher-priority layer should handle this click
+      if (shouldDeferToHigherPriorityLayer(map, e, PRODUCT_REGION_BOX_LAYER_ID)) {
         return;
       }
+
+      if (!hasFeatureAtPoint(map, e, PRODUCT_REGION_BOX_LAYER_ID)) {
+        return;
+      }
+
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: [PRODUCT_REGION_BOX_LAYER_ID],
+      });
 
       const { code } = getPropertyFromMapFeatures<{
         name: string;

--- a/src/components/Map/utils/layerPriority.ts
+++ b/src/components/Map/utils/layerPriority.ts
@@ -1,0 +1,141 @@
+import type { Map } from 'mapbox-gl';
+import { MapMouseEvent, MapRef } from 'react-map-gl/mapbox';
+import { mapboxLayerIds } from '@/constants/mapboxId';
+
+const { CURRENT_METERS_PLOT_LAYER_ID, ARGO_AS_PRODUCT_POINT_LAYER_ID, PRODUCT_REGION_BOX_LAYER_ID } = mapboxLayerIds;
+
+/**
+ * Layer priority order from highest to lowest.
+ * Layers at the top of this array have higher priority and will block clicks to lower layers.
+ *
+ * IMPORTANT: Layers may be conditionally rendered (e.g., only shown for certain products).
+ * The utility functions automatically check if a layer exists before querying it.
+ */
+export const INTERACTIVE_LAYER_PRIORITY = [
+  CURRENT_METERS_PLOT_LAYER_ID, // Highest priority (conditionally rendered)
+  ARGO_AS_PRODUCT_POINT_LAYER_ID, // (conditionally rendered)
+  PRODUCT_REGION_BOX_LAYER_ID, // Lowest priority (conditionally rendered)
+] as const;
+
+/**
+ * Layers that should block region hover effects when they have features.
+ *
+ * - Argo points: Independent observations, shouldn't show region highlight
+ * - CurrentMeter points: NOT in this list, so region highlight shows (dual effect)
+ */
+export const LAYERS_BLOCKING_REGION_HOVER = [ARGO_AS_PRODUCT_POINT_LAYER_ID] as const;
+
+/**
+ * Checks if any higher-priority layers have features at the click point.
+ * Use this to prevent handling clicks when a higher-priority layer should handle it.
+ *
+ * @param map - Mapbox map instance
+ * @param e - Map click event
+ * @param currentLayerId - The layer ID checking for priority
+ * @returns true if a higher-priority layer has a feature at the click point
+ *
+ * @example
+ * const handleMouseClick = useCallback((e: MapMouseEvent) => {
+ *   if (!map) return;
+ *
+ *   // Don't handle click if a higher-priority layer has a feature here
+ *   if (shouldDeferToHigherPriorityLayer(map, e, PRODUCT_REGION_BOX_LAYER_ID)) {
+ *     return;
+ *   }
+ *
+ *   // Continue with click handling...
+ * }, [map]);
+ */
+export const shouldDeferToHigherPriorityLayer = (
+  map: Map | MapRef,
+  e: MapMouseEvent,
+  currentLayerId: string,
+): boolean => {
+  const currentLayerIndex = INTERACTIVE_LAYER_PRIORITY.indexOf(
+    currentLayerId as (typeof INTERACTIVE_LAYER_PRIORITY)[number],
+  );
+
+  // If layer not found or is highest priority, don't defer
+  if (currentLayerIndex === -1 || currentLayerIndex === 0) {
+    return false;
+  }
+
+  // Check all higher-priority layers (those before current layer in array)
+  const higherPriorityLayers = INTERACTIVE_LAYER_PRIORITY.slice(0, currentLayerIndex);
+
+  for (const layerId of higherPriorityLayers) {
+    const layer = map.getLayer(layerId);
+    if (!layer) {
+      continue;
+    }
+
+    const features = map.queryRenderedFeatures(e.point, {
+      layers: [layerId],
+    });
+
+    if (features.length > 0) {
+      return true; // A higher-priority layer has a feature here
+    }
+  }
+
+  return false; // No higher-priority layers have features here
+};
+
+/**
+ * Checks if the current layer has any features at the click point.
+ * Use this for early return if the layer has no features to handle.
+ *
+ * @param map - Mapbox map instance
+ * @param e - Map click event
+ * @param layerId - The layer ID to check
+ * @returns true if the layer has features at the click point
+ */
+export const hasFeatureAtPoint = (map: Map | MapRef, e: MapMouseEvent, layerId: string): boolean => {
+  const layer = map.getLayer(layerId);
+  if (!layer) {
+    return false; // Layer doesn't exist (conditionally rendered)
+  }
+
+  const features = map.queryRenderedFeatures(e.point, {
+    layers: [layerId],
+  });
+
+  return features.length > 0;
+};
+
+/**
+ * Checks if region hover should be blocked by a higher-priority layer.
+ * Some layers (like Argo points) should block region highlighting, while others
+ * (like CurrentMeter plots) should allow dual hover effects.
+ *
+ * @param map - Mapbox map instance
+ * @param e - Map hover event
+ * @returns true if a layer that blocks region hover has a feature here
+ *
+ * @example
+ * // In RegionPolygonLayer hover handler:
+ * if (shouldBlockRegionHover(map, e)) {
+ *   clearRegionHover();
+ *   return;
+ * }
+ * // Continue with region highlighting...
+ */
+export const shouldBlockRegionHover = (map: Map | MapRef, e: MapMouseEvent): boolean => {
+  for (const layerId of LAYERS_BLOCKING_REGION_HOVER) {
+    // Check if the layer exists on the map first
+    const layer = map.getLayer(layerId);
+    if (!layer) {
+      continue; // Skip layers that don't exist (conditionally rendered)
+    }
+
+    const features = map.queryRenderedFeatures(e.point, {
+      layers: [layerId],
+    });
+
+    if (features.length > 0) {
+      return true; // This layer blocks region hover
+    }
+  }
+
+  return false; // No blocking layers have features here
+};

--- a/src/constants/mapboxId.ts
+++ b/src/constants/mapboxId.ts
@@ -19,8 +19,8 @@ const mapboxLayerIds = {
   PRODUCT_REGION_NAME_LABEL_LAYER_ID: 'product-region-name-label-layer-id',
   PRODUCT_REGION_SELECTED_BOX_LAYER_ID: 'product-region-selected-box-layer-id',
 
-  CURRENT_METERS_BOX_LAYER_ID: 'current-meters-box-layer-id',
-  CURRENT_METERS_SELECTED_BOX_LAYER_ID: 'current-meters-selected-box-layer-id',
+  CURRENT_METERS_PLOT_LAYER_ID: 'current-meters-plot-layer-id',
+  CURRENT_METERS_SELECTED_PLOT_LAYER_ID: 'current-meters-selected-plot-layer-id',
 } as const;
 
 export { mapboxInstanceIds, mapboxSourceIds, mapboxLayerIds };


### PR DESCRIPTION
Add centralised priority system to prevent overlapping click/hover events across multiple map layers (CurrentMeter, Argo, Region polygons).

- Add layerPriority.ts with priority configuration and utilities
- Update RegionPolygonLayer, ArgoAsProductLayer, CurrentMetersDeploymentPlotsLayer
- Support selective hover blocking: Argo blocks region hover, CurrentMeter allows dual effect