### PR TITLE
:fire: remove deprecated CLIM_CNESCARS product & rename API constants

### DIFF
--- a/src/configs/products/data-source.ts
+++ b/src/configs/products/data-source.ts
@@ -4,7 +4,7 @@ import { ProductID, RootProductID } from '@/types/product';
  * List of product IDs that should fetch from API
  * Add products here as they become API-ready
  */
-export const API_ENABLED_PRODUCTS: ProductID[] = [
+export const API_IMAGE_LIST_ENABLED_PRODUCTS: ProductID[] = [
   'fourHourSst-sstFilled',
   'fourHourSst-sst',
   'fourHourSst-sstAge',
@@ -39,13 +39,15 @@ export const API_LATEST_DATES_DISABLED_PRODUCTS: ProductID[] = [
   'currentMeters-deepADCP',
   'currentMeters-deepADV',
   'currentMeters-southernOcean',
+  'monthlyMeans-anomalies',
+  'monthlyMeans-CLIM_OFAM3_SSTAARS',
 ];
 
 /**
  * List of product IDs that will always use fixed data regardless of API implementation
  * These are typically products with simple monthly data or other special cases
  */
-export const FIXED_DATA_PRODUCTS: ProductID[] = ['monthlyMeans-anomalies', 'monthlyMeans-CLIM_OFAM3_SSTAARS'];
+export const FIXED_IMAGE_LIST_PRODUCTS: ProductID[] = ['monthlyMeans-anomalies', 'monthlyMeans-CLIM_OFAM3_SSTAARS'];
 
 export const PRODUCTS_WITH_ARGO_DATA: RootProductID[] = [
   'fourHourSst',

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -243,7 +243,7 @@ export const OC_PRODUCTS: Product[] = [
         },
       },
       {
-        title: 'OFAM3/SSTARS',
+        title: 'OFAM3/SSTAARS',
         key: 'monthlyMeans-CLIM_OFAM3_SSTAARS',
         path: 'CLIM_OFAM3_SSTAARS',
         imgPath: 'CLIM_OFAM3_SSTAARS',
@@ -252,6 +252,8 @@ export const OC_PRODUCTS: Product[] = [
           stateFormat: DateFormat.MONTH_ONLY,
         },
       },
+      /*
+      This product was removed from the original site.
       {
         title: 'CNES MDT/CARS SST',
         key: 'monthlyMeans-CLIM_CNESCARS',
@@ -262,6 +264,7 @@ export const OC_PRODUCTS: Product[] = [
           stateFormat: DateFormat.MONTH_ONLY,
         },
       },
+      */
     ],
   },
   {

--- a/src/data/regionList.ts
+++ b/src/data/regionList.ts
@@ -106,10 +106,13 @@ export const productRegionMap: ProductRegionMap = {
     state: ['NW_mm', 'NE_mm', 'SE_mm', 'SO_mm', 'GAB_mm', 'SW_mm', 'SLA30d', 'SST30d'],
     local: [],
   },
+  /*
+  This product was removed from the original site.
   'monthlyMeans-CLIM_CNESCARS': {
     state: ['NW_mm', 'NE_mm', 'SE_mm', 'SO_mm', 'GAB_mm', 'SW_mm', 'SLA30d', 'SST30d'],
     local: [],
   },
+  */
   'fourHourSst-sst': {
     state: [],
     local: [

--- a/src/hooks/useDateList/useDateList.ts
+++ b/src/hooks/useDateList/useDateList.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { getDateFormatByProductIdAndRegionScope } from '@/utils/date-utils/date';
 import { ProductID } from '@/types/product';
-import { API_ENABLED_PRODUCTS, FIXED_DATA_PRODUCTS } from '@/configs/products';
+import { API_IMAGE_LIST_ENABLED_PRODUCTS, FIXED_IMAGE_LIST_PRODUCTS } from '@/configs/products';
 import { fetchImageListByProductIdAndRegion } from '@/services/imageList';
 import { ImageFile, ImageListResponse } from '@/types/imageList';
 import { fetchArgoProfileCyclesByWmoId } from '@/services/argo';
@@ -108,7 +108,8 @@ const shouldUseSealCtdProcessor = (productId: ProductID, files: ImageFile[]): bo
 };
 
 const useDateList = ({ productId, isFreeMode = false }: UseDateListOptions) => {
-  const shouldUseApi = API_ENABLED_PRODUCTS.includes(productId) && !FIXED_DATA_PRODUCTS.includes(productId);
+  const shouldUseApi =
+    API_IMAGE_LIST_ENABLED_PRODUCTS.includes(productId) && !FIXED_IMAGE_LIST_PRODUCTS.includes(productId);
 
   const regionScope = useProductStore((state) => state.productParams.regionScope);
   const regionCodeFromStore = useProductStore((state) => state.productParams.regionCode);

--- a/src/hooks/useDateRange/useDateRange.ts
+++ b/src/hooks/useDateRange/useDateRange.ts
@@ -70,8 +70,7 @@ const useDateRange = (): UseDateRangeReturn => {
 
   const disableVideoCreation = (): boolean => {
     const isFourHourSst = mainProduct?.key === 'fourHourSst' && subProduct?.key === 'fourHourSst-sstAge';
-    const isMonthlyMeansClimatology =
-      subProduct?.key === 'monthlyMeans-CLIM_OFAM3_SSTAARS' || subProduct?.key === 'monthlyMeans-CLIM_CNESCARS';
+    const isMonthlyMeansClimatology = subProduct?.key === 'monthlyMeans-CLIM_OFAM3_SSTAARS';
     const isClimatology = mainProduct?.key === 'climatology';
     const isAdjustedSeaLevelAnomalyWithSST = mainProduct?.key === 'adjustedSeaLevelAnomaly' && !subProduct?.key;
     const isSSTTimeseries = subProduct?.key === 'sixDaySst-timeseries';

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -38,7 +38,7 @@ export type ChildProductID =
   // Monthly Means children
   | 'monthlyMeans-anomalies'
   | 'monthlyMeans-CLIM_OFAM3_SSTAARS'
-  | 'monthlyMeans-CLIM_CNESCARS'
+  // | 'monthlyMeans-CLIM_CNESCARS' // This product was removed from the original site
   // Climatology children
   | 'climatology-sst'
   | 'climatology-dataCount'
@@ -101,7 +101,7 @@ export const childProductIDs: ChildProductID[] = [
   'adjustedSeaLevelAnomaly-nonTidalSla',
   'monthlyMeans-anomalies',
   'monthlyMeans-CLIM_OFAM3_SSTAARS',
-  'monthlyMeans-CLIM_CNESCARS',
+  // 'monthlyMeans-CLIM_CNESCARS', // This product was removed from the original site
   'climatology-sst',
   'climatology-dataCount',
   'tidalCurrents-spd',

--- a/src/utils/data-image-builder-utils/dataImgBuilder.test.ts
+++ b/src/utils/data-image-builder-utils/dataImgBuilder.test.ts
@@ -194,18 +194,18 @@ describe('buildProductImageUrlByProductId', () => {
   });
 
   describe('monthlyMeans', () => {
-    it('should return the correct image url for CLIM_CNESCARS', () => {
+    it('should return the correct image url for CLIM_OFAM3_SSTAARS', () => {
       // Arrange
-      const productId = 'monthlyMeans-CLIM_CNESCARS';
-      const region = 'Au';
+      const productId = 'monthlyMeans-CLIM_OFAM3_SSTAARS';
+      const region = 'SW_mm';
       const regionScope = RegionScope.State;
-      const date = '202405';
+      const date = '202402';
 
       // Act
       const imageUrl = buildProductImageUrl(productId, region, regionScope, date);
 
       // Assert
-      expect(imageUrl).toBe(`${imageBaseUrl}/30d_MEAN_v1/CLIM_CNESCARS/Au/05.gif`);
+      expect(imageUrl).toBe(`${imageBaseUrl}/30d_MEAN/CLIM_OFAM3_SSTAARS/SW_mm/02.gif`);
     });
 
     it('should return the correct image URL for anomalies', () => {

--- a/src/utils/data-image-builder-utils/dataImgBuilder.ts
+++ b/src/utils/data-image-builder-utils/dataImgBuilder.ts
@@ -37,9 +37,12 @@ const getProductSegmentByProductId = (productId: ProductID, regionScope: RegionS
     throw new Error(`Product with id ${productId} not found`);
   }
 
+  /*
+  This product was removed from the original site.
   if (productId === 'monthlyMeans-CLIM_CNESCARS') {
     return '30d_MEAN_v1';
   }
+  */
 
   const segment = regionScope === RegionScope.State ? product.stateSegment : product.localSegment;
   return segment ? `${segment}` : '';


### PR DESCRIPTION
- Rename API_ENABLED_PRODUCTS to API_IMAGE_LIST_ENABLED_PRODUCTS for clarity
- Rename FIXED_DATA_PRODUCTS to FIXED_IMAGE_LIST_PRODUCTS for consistency
- Remove deprecated monthlyMeans-CLIM_CNESCARS product and related references
- Add monthlyMeans products to API_LATEST_DATES_DISABLED_PRODUCTS list
- Fix typo: OFAM3/SSTARS → OFAM3/SSTAARS
- Update corresponding tests and type definitions