### PR TITLE
:bug: fix surface waves buoy timeseries data not displaying on click

### DIFF
--- a/src/stores/product-store/hooks/useShowProductOverMap.ts
+++ b/src/stores/product-store/hooks/useShowProductOverMap.ts
@@ -4,12 +4,16 @@ import useProductStore from '../productStore';
 import useProductCheck from './useProductCheck';
 
 export const useShowProductOverMap = (): boolean => {
-  const { isArgo } = useProductCheck();
+  const { isArgo, isSurfaceWavesBuoyTimeseries } = useProductCheck();
   const { isArgoValid } = useArgoProductValidQueryParams();
 
   const { getQueryParamsByKey } = useQueryParams();
   const region = getQueryParamsByKey('region');
   const useProductId = useProductStore((state) => state.productParams.productId);
+
+  if (isSurfaceWavesBuoyTimeseries) {
+    return true;
+  }
 
   if (isArgo) {
     return isArgoValid;


### PR DESCRIPTION
Add early return in useShowProductOverMap to allow surface waves buoy timeseries data to display on the map.