### PR TITLE
:bug: fix data source links in data vis sidebar

### DIFF
--- a/src/components/DataVisualisationSidebar/utils.ts
+++ b/src/components/DataVisualisationSidebar/utils.ts
@@ -5,23 +5,18 @@ import { productInfoList } from './components/ProductDescriptionModal/ProductSum
 export const dataSources: (date: Dayjs) => DataSource[] = (date) => {
   return [
     {
-      title: 'SST L3S-6d ngt (1992-2017)',
-      link: `https://thredds.aodn.org.au/thredds/catalog/IMOS/SRS/SST/ghrsst/L3S-6d/ngt/${date.format('YYYY')}/catalog.html?dataset=IMOS/SRS/SST/ghrsst/L3S-6d/ngt/${date.format('YYYY')}/${date.format('YYYYMMDD')}032000-ABOM-L3S_GHRSST-SSTskin-AVHRR_D-6d_night.nc`,
-      product: ['sixDaySst', 'EACMooringArray'],
-    },
-    {
       title: 'SST L3SM-6d ngt (2018-now)',
       link: `https://thredds.aodn.org.au/thredds/catalog/IMOS/SRS/SST/ghrsst/L3SM-6d/ngt/${date.format('YYYY')}/catalog.html?dataset=IMOS/SRS/SST/ghrsst/L3SM-6d/ngt/${date.format('YYYY')}/${date.format('YYYYMMDD')}032000-ABOM-L3S_GHRSST-SSTskin-MultiSensor-6d_night.nc`,
       product: ['sixDaySst', 'EACMooringArray'],
     },
     {
       title: 'GSLA',
-      link: `https://thredds.aodn.org.au/thredds/catalog/IMOS/OceanCurrent/GSLA/NRT/${date.format('YYYY')}/catalog.html?dataset=IMOS/OceanCurrent/GSLA/NRT/${date.format('YYYY')}/IMOS_OceanCurrent_HV_${date.format('YYYYMMDD')}T060000Z_GSLA_FV02_NRT.nc`,
+      link: 'https://thredds.aodn.org.au/thredds/catalog/IMOS/OceanCurrent/GSLA/catalog.html',
       product: ['sixDaySst', 'EACMooringArray'],
     },
     {
       title: 'SSTAARS',
-      link: 'https://portal.aodn.org.au/search?uuid=79c8eea2-4e86-4553-8237-4728e27abe10',
+      link: 'https://thredds.aodn.org.au/thredds/catalog/CSIRO/Climatology/SSTAARS/catalog.html',
       product: ['sixDaySst', 'climatology', 'EACMooringArray'],
     },
     {


### PR DESCRIPTION
Updated GSLA and SSTAARS links to point to correct catalog locations and removed outdated SST L3S-6d entry.