### PR TITLE
:bug: replace wave with map and remove legend in wave product (#337)

### DIFF
--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -34,10 +34,10 @@ const ProductSideBar: React.FC = () => {
   const { mainProduct, subProduct, subProducts } = useProductConvert();
   const { updateQueryParamsAndNavigate, getQueryParamsByKey } = useQueryParams();
   const useDate = useDateStore((state) => state.date);
-  const { isArgo, isCurrentMeters, isSealCtd, isMonthlyMeans } = useProductCheck();
+  const { isArgo, isCurrentMeters, isSealCtd, isMonthlyMeans, isSurfaceWaves } = useProductCheck();
   const shouldRenderMiniMap = useShowProductOverMap();
 
-  const shouldShowLegend = !isCurrentMeters && !isMonthlyMeans;
+  const shouldShowLegend = !isCurrentMeters && !isMonthlyMeans && !isSurfaceWaves;
 
   const mooredInstrumentArrayPath = useMemo(() => {
     return (

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -202,7 +202,7 @@ export const OC_PRODUCTS: Product[] = [
     stateSegment: 'WAVES',
     children: [
       {
-        title: 'Wave',
+        title: 'Map',
         key: 'surfaceWaves-wave',
         path: 'wave',
         imgPath: 'WAVES',


### PR DESCRIPTION
Updated surface waves product title from 'Wave' to 'Map' and hidden the legend display for the wave product.