### PR TITLE
:bug: fix monthly means default route to use 30-day

### DIFF
--- a/src/configs/products/default-routes.ts
+++ b/src/configs/products/default-routes.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SUB_PRODUCT_ROUTES: Record<ProductGroupID, string> = {
   sixDaySst: 'sst',
   oceanColour: 'chl-a',
   adjustedSeaLevelAnomaly: 'sla',
-  monthlyMeans: 'anomalies',
+  monthlyMeans: '30-day',
   climatology: 'sst',
   tidalCurrents: 'speed',
   currentMeters: 'moored-instrument-array',

--- a/src/data/linksData.ts
+++ b/src/data/linksData.ts
@@ -62,7 +62,7 @@ export const linksData: LinkItem[] = [
 
         title: 'Monthly Means',
         description: 'Monthly temperature averages',
-        url: '/map/monthly-means/anomalies',
+        url: '/map/monthly-means/30-day',
       },
       {
         id: 'climatology-sst',


### PR DESCRIPTION
Updated default sub-product route and home page link to prevent error when navigating to monthly means.