### PR TITLE
:bug: fix bathymetry disappearing after zoom level 7

### DIFF
--- a/src/components/Map/data/map-style.bathymetry.json
+++ b/src/components/Map/data/map-style.bathymetry.json
@@ -81,7 +81,7 @@
       "source": "bathymetry",
       "source-layer": "depth",
       "minzoom": 0,
-      "maxzoom": 7,
+      "maxzoom": 12,
       "paint": {
         "fill-color": [
           "interpolate",


### PR DESCRIPTION
Increased maxzoom from 7 to 12 to keep bathymetry visible at higher zoom levels.