### PR TITLE
:speech_balloon: update GIF text casing and ContentType enum naming

### DIFF
--- a/src/components/VideoCreation/VideoCreation.test.tsx
+++ b/src/components/VideoCreation/VideoCreation.test.tsx
@@ -75,13 +75,13 @@ describe('VideoCreation Factory Component', () => {
   it('should not open GIF options if download option is disabled', () => {
     render(<VideoCreation disabled={true} />);
     clickDownloadOption();
-    expect(screen.queryByText('Customise Gif')).not.toBeInTheDocument();
+    expect(screen.queryByText('Customise GIF')).not.toBeInTheDocument();
   });
 
   it('opens the GIF options when enabled and clicked', () => {
     render(<VideoCreation />);
     clickDownloadOption();
-    expect(screen.getByText('Customise Gif')).toBeInTheDocument();
+    expect(screen.getByText('Customise GIF')).toBeInTheDocument();
   });
 
   it.skip('updates frame rate when changed', async () => {

--- a/src/components/VideoCreation/components/ActiveVideoCreation.test.tsx
+++ b/src/components/VideoCreation/components/ActiveVideoCreation.test.tsx
@@ -40,7 +40,7 @@ describe('ActiveVideoCreation Component', () => {
   it('toggles GIF options when clicked', () => {
     render(<ActiveVideoCreation />);
     fireEvent.click(screen.getByTestId('product-menu-bar-download-option'));
-    expect(screen.getByText('Customise Gif')).toBeInTheDocument();
+    expect(screen.getByText('Customise GIF')).toBeInTheDocument();
   });
 
   it('calls resetState when opening GIF options', () => {

--- a/src/components/VideoCreation/components/DisabledVideoCreation.test.tsx
+++ b/src/components/VideoCreation/components/DisabledVideoCreation.test.tsx
@@ -19,6 +19,6 @@ describe('DisabledVideoCreation Component', () => {
   it('does not open options when clicked', () => {
     render(<DisabledVideoCreation />);
     fireEvent.click(screen.getByTestId('product-menu-bar-download-option'));
-    expect(screen.queryByText('Customise Gif')).not.toBeInTheDocument();
+    expect(screen.queryByText('Customise GIF')).not.toBeInTheDocument();
   });
 });

--- a/src/components/VideoCreation/components/VideoCreationUI.test.tsx
+++ b/src/components/VideoCreation/components/VideoCreationUI.test.tsx
@@ -15,6 +15,6 @@ describe('VideoCreationUI Component', () => {
 
   it('renders GIF options when showGifOptions is true', () => {
     render(<VideoCreationUI showGifOptions={true} />);
-    expect(screen.getByText('Customise Gif')).toBeInTheDocument();
+    expect(screen.getByText('Customise GIF')).toBeInTheDocument();
   });
 });

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -1,5 +1,5 @@
 export enum ContentType {
-  Json = 'application/json',
-  Text = 'text/plain',
-  Gif = 'image/gif',
+  JSON = 'application/json',
+  TEXT = 'text/plain',
+  GIF = 'image/gif',
 }

--- a/src/constants/textConstant.ts
+++ b/src/constants/textConstant.ts
@@ -22,8 +22,8 @@ export enum ProductSidebarText {
 
 export enum ProductMenubarText {
   SHARE = 'Share',
-  CUSTOMISE_GIF = 'Customise Gif',
-  DOWNLOAD_GIF = 'Download Gif',
+  CUSTOMISE_GIF = 'Customise GIF',
+  DOWNLOAD_GIF = 'Download GIF',
   COPIED = 'Copied',
   VIDEO = 'Video',
   EXIT_VIDEO = 'Exit Video',

--- a/src/services/argo.ts
+++ b/src/services/argo.ts
@@ -12,7 +12,7 @@ const fetchArgoProfilesByDate = async (date: Dayjs) => {
 
   return await ec2ProxyClient.get<string>(`/profiles/map/${validatedDate.format('YYYYMMDD')}`, {
     headers: {
-      'Content-Type': ContentType.Text,
+      'Content-Type': ContentType.TEXT,
     },
   });
 };
@@ -29,7 +29,7 @@ const fetchArgoTags = async (dateString: string, tagPath: string, regionPath: st
 
   const response = await ec2ProxyClient.get<string>(`/${tagPath}/TAGS/${regionPath}/${dateString}.txt`, {
     headers: {
-      'Content-Type': ContentType.Text,
+      'Content-Type': ContentType.TEXT,
     },
   });
 

--- a/src/services/currentMeters.ts
+++ b/src/services/currentMeters.ts
@@ -18,7 +18,7 @@ const getCurrentMetersPlotsList = async (
   try {
     const htmlString = await ec2ProxyClient.get<string>(`timeseries/${folder}/${deploymentPlot}/${type}/`, {
       headers: {
-        'Content-Type': ContentType.Text,
+        'Content-Type': ContentType.TEXT,
       },
     });
 

--- a/src/services/sealCtd.ts
+++ b/src/services/sealCtd.ts
@@ -32,7 +32,7 @@ const getSealCtdGraphTags = async (imageUrl: string) => {
   try {
     const response = await ec2ProxyClient.get<string>(tagUrl, {
       headers: {
-        'Content-Type': ContentType.Text,
+        'Content-Type': ContentType.TEXT,
       },
     });
 
@@ -52,7 +52,7 @@ const getSealCtdMapTags = async (regionCode: string, date: string) => {
   try {
     const response = await ec2ProxyClient.get<string>(tagUrl, {
       headers: {
-        'Content-Type': ContentType.Text,
+        'Content-Type': ContentType.TEXT,
       },
     });
 

--- a/src/services/tidalCurrents.ts
+++ b/src/services/tidalCurrents.ts
@@ -34,7 +34,7 @@ const getTidalCurrentsTagsData = async (date: Dayjs, subProduct: string, region:
   try {
     const htmlString = await ec2ProxyClient.get<string>(url, {
       headers: {
-        'Content-Type': ContentType.Text,
+        'Content-Type': ContentType.TEXT,
       },
     });
 


### PR DESCRIPTION
Correct "Gif" to "GIF" in UI labels and rename ContentType enum values to SCREAMING_CASE convention.