### PR TITLE
:bug: fix ocean colour state-level image URL for non-chlA products

### DIFF
--- a/src/utils/data-image-builder-utils/dataImgBuilder.test.ts
+++ b/src/utils/data-image-builder-utils/dataImgBuilder.test.ts
@@ -191,6 +191,23 @@ describe('buildProductImageUrlByProductId', () => {
       // Assert
       expect(imageUrl).toBe(`${imageBaseUrl}/STATE_daily/CHL/SE/20240717.gif`);
     });
+
+    it('should return the correct image URL for chlAAge state region (not routed through buildOceanColourImageUrl)', () => {
+      // Arrange
+      const productId = 'oceanColour-chlAAge';
+      const region = 'SE';
+      const regionScope = RegionScope.State;
+      const date = '20240717';
+      const oceanColourDateList = [{ date: '20240717', path: '/SE_chl/2024' }];
+
+      // Act
+      const imageUrl = buildStaticImageUrl(productId, dayjs(date), region, regionScope, regionScope, region, {
+        oceanColourDateList,
+      });
+
+      // Assert - should use buildDefaultFallbackImageUrl path, not buildOceanColourImageUrl
+      expect(imageUrl).toBe(`${imageBaseUrl}/STATE_daily/CHL_AGE/SE/20240717.gif`);
+    });
   });
 
   describe('monthlyMeans', () => {

--- a/src/utils/data-image-builder-utils/dataImgBuilder.ts
+++ b/src/utils/data-image-builder-utils/dataImgBuilder.ts
@@ -381,7 +381,7 @@ const buildStaticImageUrl = (
       return buildSealCtdMapImageUrl(regionCode ?? 'POLAR', date);
     case productId === 'surfaceWaves-wave':
       return buildSurfaceWavesImageUrl(date);
-    case productId.startsWith('oceanColour-') && !!options?.oceanColourDateList: {
+    case productId === 'oceanColour-chlA' && !!options?.oceanColourDateList: {
       const dateFormat = getDateFormatByProductIdAndRegionScope(productId, regionScope);
       const formattedDate = date.format(dateFormat);
       return buildOceanColourImageUrl(regionPath, formattedDate, options.oceanColourDateList, options.isProxyRequired);


### PR DESCRIPTION
Restrict buildOceanColourImageUrl to only oceanColour-chlA so other ocean colour products use the default fallback path for state regions.