### PR TITLE
:sparkles: display build version in footer

### DIFF
--- a/.github/workflows/cd_edge.yml
+++ b/.github/workflows/cd_edge.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -98,4 +98,11 @@ describe('Footer Component', () => {
     const copyrightText = screen.getByText(/© IMOS \d{4}/);
     expect(copyrightText).toBeVisible();
   });
+
+  it('should render version information', () => {
+    render(<Footer />);
+
+    const versionText = screen.getByText(/version/i);
+    expect(versionText).toBeVisible();
+  });
 });

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -86,8 +86,9 @@ const Footer: React.FC = () => {
           <div className="flex items-center justify-between gap-1 sm:gap-4">
             <div className="flex items-center">
               <p className="text-base text-imos-nav-text">
-                {COPYRIGHT_TEXT}
-                Version: {appVersion}
+                <span>{COPYRIGHT_TEXT}</span>
+                <span>. </span>
+                <span>Version: {appVersion}</span>
               </p>
             </div>
             <div className="flex flex-nowrap gap-1 sm:gap-3">

--- a/src/components/Footer/consts.ts
+++ b/src/components/Footer/consts.ts
@@ -49,7 +49,7 @@ export const FOOTER_ACKNOWLEDGE_TEXT: string =
   'peoples past and present.';
 
 export const FEEDBACK_LINK: string = 'https://github.com/aodn/ocean-current-frontend/issues/new/choose';
-export const COPYRIGHT_TEXT: string = `© IMOS ${dayjs().year()}. `;
+export const COPYRIGHT_TEXT: string = `© IMOS ${dayjs().year()}`;
 
 export const CONTACT_EMAIL: string = 'info@aodn.org.au';
 export const CONTACT_SUBJECT: string = 'Ocean Current Enquiry';

--- a/src/configs/version.ts
+++ b/src/configs/version.ts
@@ -1,1 +1,1 @@
-export const appVersion = import.meta.env.VITE_APP_VERSION ?? 'local';
+export const appVersion = import.meta.env.VITE_APP_VERSION || 'local';


### PR DESCRIPTION
Inject VITE_APP_VERSION at build time — short commit hash for edge builds, git tag for production. Falls back to 'local' when running locally.