### PR TITLE
:construction_worker: include branch name in edge build version

### DIFF
--- a/.github/workflows/cd_edge.yml
+++ b/.github/workflows/cd_edge.yml
@@ -44,7 +44,7 @@ jobs:
         run: YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
       - name: Set version
-        run: echo "VITE_APP_VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "VITE_APP_VERSION=${{ github.event.workflow_run.head_branch }}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build the front end
         env:


### PR DESCRIPTION
Prefix the build version with the branch name so it reads as "main-abc1234" instead of just "abc1234".