### PR TITLE
:sparkles: add detailed EAC mooring dataset modal

### DIFF
--- a/src/assets/icons/cross-icon.svg
+++ b/src/assets/icons/cross-icon.svg
@@ -1,8 +1,8 @@
- <svg
+<svg
   xmlns="http://www.w3.org/2000/svg"
-  fill="none"
-  viewBox="0 0 24 24"
-  stroke="currentColor"
+  fill="currentColor"
+  viewBox="0 0 40 40"
+  stroke="none"
 >
-  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+  <path d="M29.51,8.43c.57-.57,1.49-.57,2.06,0,.57.57.57,1.49,0,2.06l-9.51,9.51,9.51,9.51.1.11c.47.57.43,1.42-.1,1.95-.57.57-1.5.57-2.07,0l-9.5-9.51-9.5,9.51c-.57.57-1.5.57-2.07,0-.53-.53-.57-1.38-.1-1.95l.1-.11,9.5-9.51-9.51-9.51c-.57-.57-.57-1.49,0-2.06.57-.57,1.49-.57,2.06,0l9.51,9.51,9.51-9.51Z"/>
 </svg>

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
@@ -2078,7 +2078,7 @@ const EACMooringArrayAboutData = () => {
         </p>
         <p>
           In IMOS-OceanCurrent, we have used the gridded product to calculate daily temperature, salinity, and velocity
-          anomalies for the 8 years of EAC mooring array data. The result are vertical sections of these properties,
+          anomalies for the 8 years of EAC mooring array data. The results are vertical sections of these properties,
           showing how the EAC changes in time. To aid interpretation, we show these vertical sections alongside our
           usual maps of remotely-sensed data, with Argo floats occasionally complementing the sub-surface data near the
           array.

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
@@ -2008,6 +2008,115 @@ const SurfaceWaveModalData = () => {
   );
 };
 
+const EACMooringArrayAboutData = () => {
+  return (
+    <div className="flex flex-col gap-6 p-6 md:flex-row">
+      <div className="flex-1 space-y-4 text-base leading-relaxed text-imos-nav-text">
+        <p>
+          The East Australian Current (EAC) is the complex, highly energetic western boundary current that flows along
+          the east coast of Australia. As the strongest current in the region, the EAC and its associated turbulent
+          eddies dominate the marine climate of the Coral and Tasman Seas and of the eastern Australian continental
+          shelf.
+        </p>
+        <p>
+          Variability in the EAC&apos;s strength, location, and property transport impacts the weather, ocean
+          environment, and composition and functioning of marine ecosystems of the region. However, the influence of the
+          EAC on the regional climate, shelf-coastal exchange processes, and the marine ecosystems is not well
+          understood due in part to the paucity of long-term ocean observations.
+        </p>
+        <p>
+          To begin to address the need of the long-term monitoring of the EAC, the Australian Integrated Marine
+          Observing System (IMOS) and CSIRO supported a comprehensive in situ mooring array at approximately 27&deg;S
+          from the continental slope to the off-shore deep ocean between 2012-2022, except for a 22-month period between
+          2013-2015 when the mooring array was not in place.
+        </p>
+        <p>
+          The array is composed of seven moorings, with the shallowest mooring being the national reference station off
+          North Stradbroke Island, and the deepest mooring extending from 4800 m to the surface (Figure 1a). Each
+          mooring is equipped with instruments that measure temperature, salinity, and horizontal velocity placed along
+          the mooring line (Figure 1b). Temperature, salinity, and some of the velocity measurements are observed at a
+          specific depth (see red, green, and blue dots in Figure 1b, respectively). Over the continental shelf and
+          slope, where the EAC is expected to be strongest, the velocity is measured every 4-16 m from the sea-surface
+          to 1000 m of the water column. These velocity measurements are taken by acoustic doppler current profiling
+          instruments (ADCPs, yellow dots in Figure 1b) and the vertical depth range of each ADCP is represented by the
+          grey cones in Figure 1b.
+        </p>
+        <p>
+          With continuous measurements of ocean properties, we can build climatological means. Using these means as
+          reference, we&apos;re able to calculate anomalies of each ocean property. Anomaly values help us to identify
+          unusual and extreme behaviours &ndash; for example an anomalously strong EAC, or extremely warm temperatures
+          at the current&apos;s sub-surface core. However, to determine mean and anomalous values of a property, the
+          continuous measurements must happen at the same coordinates and depth in the water column and be free of gaps.
+        </p>
+        <p>
+          Planned and unplanned gaps happen in the raw data for several reasons. The number or nominal depths of the
+          instruments might change between deployments, or a sensor might fail during its time in the water. Also, the
+          mooring is &ldquo;blown over&rdquo; by strong currents. As the moorings are pushed over, the instruments
+          measure ocean properties deeper than their nominal depth, sometimes leaving the shallower depths unmeasured.
+        </p>
+        <p>
+          To fill these data gaps in the EAC moorings data, a team of CSIRO experts{' '}
+          <a
+            href="https://doi.org/10.1175/JTECH-D-21-0183.1"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-imos-sea-blue"
+          >
+            used a machine learning technique
+          </a>{' '}
+          to fill temporal and vertical gaps in the raw data. The gap-filled, gridded product is fully described and
+          freely available{' '}
+          <a
+            href="https://doi.org/10.25919/sfw7-hc46"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-imos-sea-blue"
+          >
+            here
+          </a>
+          , ready for users&apos; uptake.
+        </p>
+        <p>
+          In IMOS-OceanCurrent, we have used the gridded product to calculate daily temperature, salinity, and velocity
+          anomalies for the 8 years of EAC mooring array data. The result are vertical sections of these properties,
+          showing how the EAC changes in time. To aid interpretation, we show these vertical sections alongside our
+          usual maps of remotely-sensed data, with Argo floats occasionally complementing the sub-surface data near the
+          array.
+        </p>
+        <p>
+          The dataset used here is fully described in Sloyan, B. M., Cowley, R., and Chapman, C.C. East Australian
+          Current velocity, temperature and salinity data products. <em>Sci Data</em> 11, 10 (2024).{' '}
+          <a
+            href="https://doi.org/10.1038/s41597-023-02857-x"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-imos-sea-blue"
+          >
+            https://doi.org/10.1038/s41597-023-02857-x
+          </a>
+        </p>
+      </div>
+      <div className="flex-1 space-y-4">
+        <img
+          src="/resource/EAC_fig_ADCP.gif"
+          alt="EAC mooring array Figure 1: (a) Location of the EAC moorings; (b) Vertical distribution of instruments at each mooring"
+          className="w-full rounded"
+        />
+        <p className="text-sm leading-normal text-imos-dark-grey">
+          Figure 1: (a) Location of the EAC moorings (red diamonds); (b) Vertical distribution of instruments at each
+          mooring. Australia&apos;s eastern continental shelf break and adjacent deep abyssal plain are shown in black.
+          From the continental shelf to the offshore deep ocean, the moorings are: National Reference Station North
+          Stradbroke Island (NRSNSI), EAC moorings at nominal depths of 500 m (EAC0500), 2000 m (EAC2000), 3200 m
+          (EAC3200), 4200 m (EAC4200), 4700 m (EAC4700) and 4800 m (EAC4800). The locations of instruments that measure
+          temperature/salinity, temperature, and single point velocity along each mooring line are shown as red, green,
+          and blue dots, respectively. The locations of instruments that measure current velocity over a depth range
+          (i.e., ADCPs) are shown as yellow dots, and the measured range is indicated by shaded grey cones.
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export {
   OceanColourModalData,
   SixDaySstModalData,
@@ -2015,6 +2124,7 @@ export {
   FourHourSstModalData,
   SurfaceWaveModalData,
   EACMooringArrayModalData,
+  EACMooringArrayAboutData,
   CurrentMetersModalData,
   ArgoModalData,
   TidalCurrentsModalData,

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductSummaryList.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductSummaryList.tsx
@@ -5,6 +5,7 @@ import {
   SixDaySstModalData,
   SurfaceWaveModalData,
   EACMooringArrayModalData,
+  EACMooringArrayAboutData,
   CurrentMetersModalData,
   ArgoModalData,
   TidalCurrentsModalData,
@@ -101,5 +102,8 @@ export const productInfoList: ProductInfo[] = [
     summary:
       'Daily estimates of East Australian Current (EAC) properties calculated from the CSIRO EAC gridded mooring product.',
     description: EACMooringArrayModalData,
+    aboutButtonText: 'About EAC mooring array dataset',
+    aboutTitle: 'EAC Mooring Array (2012-2022)',
+    aboutDescription: EACMooringArrayAboutData,
   },
 ];

--- a/src/components/DataVisualisationSidebar/components/ProductSummary.test.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductSummary.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProductInfo } from '../types';
+import ProductSummary from './ProductSummary';
+
+const baseProductInfo: ProductInfo = {
+  id: 'testProduct',
+  title: 'Test Product',
+  summary: 'This is a test summary for the product.',
+  description: () => <p>Description content</p>,
+};
+
+const productInfoWithAbout: ProductInfo = {
+  ...baseProductInfo,
+  aboutButtonText: 'About this dataset',
+  aboutTitle: 'Test Product (2012-2022)',
+  aboutDescription: () => <p>About content</p>,
+};
+
+describe('ProductSummary', () => {
+  it('renders nothing when summary is null', () => {
+    const { container } = render(<ProductSummary productInfo={{ ...baseProductInfo, summary: null }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when summary is empty', () => {
+    const { container } = render(<ProductSummary productInfo={{ ...baseProductInfo, summary: '' }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders summary text and Read more link', () => {
+    render(<ProductSummary productInfo={baseProductInfo} />);
+    expect(screen.getByText('This is a test summary for the product.')).toBeInTheDocument();
+    expect(screen.getByText('Read more')).toBeInTheDocument();
+  });
+
+  it('opens the Read More popup when clicked', () => {
+    render(<ProductSummary productInfo={baseProductInfo} />);
+    fireEvent.click(screen.getByText('Read more'));
+    expect(screen.getByText('Test Product')).toBeInTheDocument();
+    expect(screen.getByText('Description content')).toBeInTheDocument();
+  });
+
+  it('does not render about button when aboutButtonText is not provided', () => {
+    render(<ProductSummary productInfo={baseProductInfo} />);
+    expect(screen.queryByText('About this dataset')).not.toBeInTheDocument();
+  });
+
+  it('renders about button when aboutButtonText and aboutDescription are provided', () => {
+    render(<ProductSummary productInfo={productInfoWithAbout} />);
+    expect(screen.getByText('About this dataset')).toBeInTheDocument();
+  });
+
+  it('opens the wide popup with aboutTitle when about button is clicked', () => {
+    render(<ProductSummary productInfo={productInfoWithAbout} />);
+    fireEvent.click(screen.getByText('About this dataset'));
+    expect(screen.getByText('Test Product (2012-2022)')).toBeInTheDocument();
+    expect(screen.getByText('About content')).toBeInTheDocument();
+  });
+
+  it('uses the base title as fallback when aboutTitle is not provided', () => {
+    const info: ProductInfo = {
+      ...baseProductInfo,
+      aboutButtonText: 'About this dataset',
+      aboutDescription: () => <p>About content</p>,
+    };
+    render(<ProductSummary productInfo={info} />);
+    fireEvent.click(screen.getByText('About this dataset'));
+    // The wide popup should use the base title as fallback
+    const titles = screen.getAllByText('Test Product');
+    expect(titles.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('locks body scroll when wide popup is open', () => {
+    render(<ProductSummary productInfo={productInfoWithAbout} />);
+    fireEvent.click(screen.getByText('About this dataset'));
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+});

--- a/src/components/DataVisualisationSidebar/components/ProductSummary.test.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductSummary.test.tsx
@@ -74,6 +74,6 @@ describe('ProductSummary', () => {
   it('locks body scroll when wide popup is open', () => {
     render(<ProductSummary productInfo={productInfoWithAbout} />);
     fireEvent.click(screen.getByText('About this dataset'));
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
   });
 });

--- a/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
@@ -7,7 +7,7 @@ import { ProductSummaryProp } from '../types';
 const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isAboutPopupOpen, setIsAboutPopupOpen] = useState(false);
-  if (!productInfo) return;
+  if (!productInfo) return null;
   const { title, summary, description, aboutButtonText, aboutTitle, aboutDescription } = productInfo;
 
   const handlePopup = () => {
@@ -46,7 +46,7 @@ const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
 
         <Popup title={title} body={PopupBody} isOpen={isPopupOpen} onClose={handlePopup} />
 
-        {aboutDescription && (
+        {aboutDescription && isAboutPopupOpen && (
           <WidePopup
             title={aboutTitle || title}
             body={() => aboutDescription() ?? <></>}

--- a/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
@@ -15,7 +15,7 @@ const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
   };
 
   const handleAboutPopup = () => {
-    setIsAboutPopupOpen(!isAboutPopupOpen);
+    setIsAboutPopupOpen((prev) => !prev);
   };
 
   const PopupBody = () => {
@@ -39,7 +39,7 @@ const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
 
           {aboutButtonText && aboutDescription && (
             <Button onClick={handleAboutPopup} size="full" borderRadius="small" type="secondary" className="mt-3">
-              <span className="text-imos-dark-grey">{aboutButtonText}</span>
+              <span className="min-w-0 truncate text-imos-dark-grey">{aboutButtonText}</span>
             </Button>
           )}
         </div>

--- a/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductSummary.tsx
@@ -1,16 +1,21 @@
 import React, { useState } from 'react';
-import { Popup, TruncateText } from '@/components/Shared';
+import { Button, Popup, WidePopup, TruncateText } from '@/components/Shared';
 import { GeneralText } from '@/constants/textConstant';
 import { ArrowWithTailIcon, InfoIcon } from '@/components/Shared/Icons';
 import { ProductSummaryProp } from '../types';
 
 const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isAboutPopupOpen, setIsAboutPopupOpen] = useState(false);
   if (!productInfo) return;
-  const { title, summary, description } = productInfo;
+  const { title, summary, description, aboutButtonText, aboutTitle, aboutDescription } = productInfo;
 
   const handlePopup = () => {
     setIsPopupOpen(!isPopupOpen);
+  };
+
+  const handleAboutPopup = () => {
+    setIsAboutPopupOpen(!isAboutPopupOpen);
   };
 
   const PopupBody = () => {
@@ -31,9 +36,24 @@ const ProductSummary: React.FC<ProductSummaryProp> = ({ productInfo }) => {
             <p className="mr-2 cursor-pointer font-semibold text-imos-dark-grey">{GeneralText.READ_MORE}</p>
             <ArrowWithTailIcon className="cursor-pointer" />
           </div>
+
+          {aboutButtonText && aboutDescription && (
+            <Button onClick={handleAboutPopup} size="full" borderRadius="small" type="secondary" className="mt-3">
+              <span className="text-imos-dark-grey">{aboutButtonText}</span>
+            </Button>
+          )}
         </div>
 
         <Popup title={title} body={PopupBody} isOpen={isPopupOpen} onClose={handlePopup} />
+
+        {aboutDescription && (
+          <WidePopup
+            title={aboutTitle || title}
+            body={() => aboutDescription() ?? <></>}
+            isOpen={isAboutPopupOpen}
+            onClose={handleAboutPopup}
+          />
+        )}
       </>
     )
   );

--- a/src/components/DataVisualisationSidebar/types.ts
+++ b/src/components/DataVisualisationSidebar/types.ts
@@ -6,6 +6,9 @@ export type ProductInfo = {
   summary: string | null;
   description: () => JSX.Element | null;
   title: string;
+  aboutButtonText?: string;
+  aboutTitle?: string;
+  aboutDescription?: () => JSX.Element | null;
   childrenInfo?: {
     [childId: string]: {
       summary: string | null;

--- a/src/components/DataVisualisationSidebar/utils.ts
+++ b/src/components/DataVisualisationSidebar/utils.ts
@@ -42,6 +42,9 @@ export const getProductInfoByKey = (productKey: string, childKey?: string): Prod
       summary: childInfo.summary,
       description: childInfo.description,
       childrenInfo: parentProduct.childrenInfo,
+      aboutButtonText: parentProduct.aboutButtonText,
+      aboutTitle: parentProduct.aboutTitle,
+      aboutDescription: parentProduct.aboutDescription,
     };
   }
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -19,11 +19,8 @@ const Navbar = ({ className }: { className?: string }) => {
   const [isScrolled, setIsScrolled] = useState<boolean>(false);
 
   const handleScroll = () => {
-    if (window.scrollY > 0) {
-      setIsScrolled(true);
-    } else {
-      setIsScrolled(false);
-    }
+    if (document.body.style.position === 'fixed') return;
+    setIsScrolled(window.scrollY > 0);
   };
 
   useEffect(() => {

--- a/src/components/Shared/Popup/Popup.tsx
+++ b/src/components/Shared/Popup/Popup.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import crossImage from '@/assets/icons/cross-icon.svg';
-import { useOutsideClick } from '@/hooks';
+import { useBodyScrollLock, useOutsideClick } from '@/hooks';
 import { PopupProps } from './types/popup.types';
 
 const Popup: React.FC<PopupProps> = ({ title, body, isOpen, onClose, imageUrl, isImage = false }) => {
@@ -9,6 +9,8 @@ const Popup: React.FC<PopupProps> = ({ title, body, isOpen, onClose, imageUrl, i
   useOutsideClick<HTMLDivElement>(popupRef, () => {
     return onClose();
   });
+
+  useBodyScrollLock(isOpen);
 
   if (!isOpen) return null;
 

--- a/src/components/Shared/Popup/WidePopup.test.tsx
+++ b/src/components/Shared/Popup/WidePopup.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WidePopup from './WidePopup';
+
+describe('WidePopup', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    title: 'Test Title',
+    body: () => <p>Test body content</p>,
+  };
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<WidePopup {...defaultProps} isOpen={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the title and body when open', () => {
+    render(<WidePopup {...defaultProps} />);
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test body content')).toBeInTheDocument();
+  });
+
+  it('renders the close button', () => {
+    render(<WidePopup {...defaultProps} />);
+    expect(screen.getByAltText('Close')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<WidePopup {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByAltText('Close'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('locks body scroll when open', () => {
+    render(<WidePopup {...defaultProps} />);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores body scroll when closed', () => {
+    const { rerender } = render(<WidePopup {...defaultProps} />);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender(<WidePopup {...defaultProps} isOpen={false} />);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('renders without body prop', () => {
+    render(<WidePopup isOpen={true} onClose={vi.fn()} title="No body" />);
+    expect(screen.getByText('No body')).toBeInTheDocument();
+  });
+});

--- a/src/components/Shared/Popup/WidePopup.test.tsx
+++ b/src/components/Shared/Popup/WidePopup.test.tsx
@@ -35,15 +35,15 @@ describe('WidePopup', () => {
 
   it('locks body scroll when open', () => {
     render(<WidePopup {...defaultProps} />);
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
   });
 
   it('restores body scroll when closed', () => {
     const { rerender } = render(<WidePopup {...defaultProps} />);
-    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
 
     rerender(<WidePopup {...defaultProps} isOpen={false} />);
-    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
   });
 
   it('renders without body prop', () => {

--- a/src/components/Shared/Popup/WidePopup.test.tsx
+++ b/src/components/Shared/Popup/WidePopup.test.tsx
@@ -23,13 +23,13 @@ describe('WidePopup', () => {
 
   it('renders the close button', () => {
     render(<WidePopup {...defaultProps} />);
-    expect(screen.getByAltText('Close')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
   });
 
   it('calls onClose when close button is clicked', () => {
     const onClose = vi.fn();
     render(<WidePopup {...defaultProps} onClose={onClose} />);
-    fireEvent.click(screen.getByAltText('Close'));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/src/components/Shared/Popup/WidePopup.tsx
+++ b/src/components/Shared/Popup/WidePopup.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import crossImage from '@/assets/icons/cross-icon.svg';
+import { CrossIcon } from '@/components/Shared/Icons';
 import { useBodyScrollLock, useOutsideClick } from '@/hooks';
 
 interface WidePopupProps {
@@ -27,20 +27,20 @@ const WidePopup: React.FC<WidePopupProps> = ({ title, body, isOpen, onClose }) =
       aria-modal="true"
       aria-label={title}
     >
-      <div className="mb-8 mt-28 w-full max-w-8xl px-4 md:mt-36">
+      <div className="md:mt-22 mt-20 w-full max-w-8xl px-4 lg:mt-24">
         <div
           ref={popupRef}
-          className="flex max-h-[calc(100vh-9rem)] w-full flex-col overflow-hidden rounded-lg bg-white shadow-layout-shadow md:max-h-[calc(100vh-11rem)]"
+          className="flex max-h-[calc(100vh-13rem)] w-full flex-col overflow-hidden rounded-lg bg-white shadow-layout-shadow md:max-h-[calc(100vh-10rem)]"
         >
           <div className="relative flex shrink-0 items-center justify-center bg-imos-cloud-tint/70 px-12 py-4">
             <h2 className="text-center font-poppins text-xl font-medium text-imos-deep-blue">{title}</h2>
             <button
               type="button"
               aria-label="Close"
-              className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer opacity-80"
+              className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer border-none bg-transparent p-0 opacity-80"
               onClick={onClose}
             >
-              <img aria-hidden src={crossImage} alt="" className="h-6 w-6" />
+              <CrossIcon aria-hidden color="imos-black" size="xl" />
             </button>
           </div>
           <div className="overflow-y-auto" data-testid="wide-popup-body">

--- a/src/components/Shared/Popup/WidePopup.tsx
+++ b/src/components/Shared/Popup/WidePopup.tsx
@@ -1,0 +1,47 @@
+import React, { useRef } from 'react';
+import crossImage from '@/assets/icons/cross-icon.svg';
+import { useBodyScrollLock, useOutsideClick } from '@/hooks';
+
+interface WidePopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  body?: () => JSX.Element;
+}
+
+const WidePopup: React.FC<WidePopupProps> = ({ title, body, isOpen, onClose }) => {
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick<HTMLDivElement>(popupRef, () => {
+    return onClose();
+  });
+
+  useBodyScrollLock(isOpen);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50" aria-hidden>
+      <div className="mb-8 mt-28 w-full max-w-8xl px-4 md:mt-36">
+        <div
+          ref={popupRef}
+          className="flex max-h-[calc(100vh-9rem)] w-full flex-col overflow-hidden rounded-lg bg-white shadow-layout-shadow md:max-h-[calc(100vh-11rem)]"
+        >
+          <div className="relative flex shrink-0 items-center justify-center bg-imos-cloud-tint/70 px-12 py-4">
+            <h2 className="text-center font-poppins text-xl font-medium text-imos-deep-blue">{title}</h2>
+            <img
+              aria-hidden
+              src={crossImage}
+              alt="Close"
+              className="absolute right-4 top-1/2 h-6 w-6 -translate-y-1/2 cursor-pointer opacity-80"
+              onClick={onClose}
+            />
+          </div>
+          <div className="overflow-y-auto">{body && body()}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WidePopup;

--- a/src/components/Shared/Popup/WidePopup.tsx
+++ b/src/components/Shared/Popup/WidePopup.tsx
@@ -21,7 +21,12 @@ const WidePopup: React.FC<WidePopupProps> = ({ title, body, isOpen, onClose }) =
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50" aria-hidden>
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
       <div className="mb-8 mt-28 w-full max-w-8xl px-4 md:mt-36">
         <div
           ref={popupRef}
@@ -29,15 +34,18 @@ const WidePopup: React.FC<WidePopupProps> = ({ title, body, isOpen, onClose }) =
         >
           <div className="relative flex shrink-0 items-center justify-center bg-imos-cloud-tint/70 px-12 py-4">
             <h2 className="text-center font-poppins text-xl font-medium text-imos-deep-blue">{title}</h2>
-            <img
-              aria-hidden
-              src={crossImage}
-              alt="Close"
-              className="absolute right-4 top-1/2 h-6 w-6 -translate-y-1/2 cursor-pointer opacity-80"
+            <button
+              type="button"
+              aria-label="Close"
+              className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer opacity-80"
               onClick={onClose}
-            />
+            >
+              <img aria-hidden src={crossImage} alt="" className="h-6 w-6" />
+            </button>
           </div>
-          <div className="overflow-y-auto">{body && body()}</div>
+          <div className="overflow-y-auto" data-testid="wide-popup-body">
+            {body && body()}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Shared/index.tsx
+++ b/src/components/Shared/index.tsx
@@ -3,6 +3,7 @@ import Dropdown from './Dropdown/Dropdown';
 import Slider from './Slider/Slider';
 import Loading from './Loading/Loading';
 import Popup from './Popup/Popup';
+import WidePopup from './Popup/WidePopup';
 import ToggleButton from './ToggleButton/ToggleButton';
 import TruncateText from './TruncateText/TruncateText';
 import LinkOrAnchor from './LinkOrAnchor/LinkOrAnchor';
@@ -10,5 +11,5 @@ import ShareButton from './ShareButton/ShareButton';
 
 export * from './Collapsible';
 
-export { Button, Dropdown, Slider, Loading, Popup, ToggleButton, TruncateText, LinkOrAnchor, ShareButton };
+export { Button, Dropdown, Slider, Loading, Popup, WidePopup, ToggleButton, TruncateText, LinkOrAnchor, ShareButton };
 export * from './Overlay/Overlay';

--- a/src/hooks/useBodyScrollLock/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock/useBodyScrollLock.ts
@@ -2,10 +2,23 @@ import { useEffect } from 'react';
 
 export function useBodyScrollLock(lock: boolean) {
   useEffect(() => {
-    const original = document.body.style.overflow;
-    document.body.style.overflow = lock ? 'hidden' : original;
+    if (!lock) return;
+
+    const scrollY = window.scrollY;
+
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.overflowY = 'scroll';
+
     return () => {
-      document.body.style.overflow = original;
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.left = '';
+      document.body.style.right = '';
+      document.body.style.overflowY = '';
+      window.scrollTo(0, scrollY);
     };
   }, [lock]);
 }

--- a/tests/wide-popup.spec.ts
+++ b/tests/wide-popup.spec.ts
@@ -20,7 +20,7 @@ test.describe('Wide Popup (About dataset)', () => {
     await expect(popupTitle).toBeVisible();
 
     // Close button should be visible
-    const closeButton = page.getByAltText('Close');
+    const closeButton = page.getByRole('button', { name: 'Close' });
     await expect(closeButton).toBeVisible();
   });
 
@@ -41,7 +41,7 @@ test.describe('Wide Popup (About dataset)', () => {
     await expect(popupTitle).toBeVisible();
 
     // Click close button
-    await page.getByAltText('Close').click();
+    await page.getByRole('button', { name: 'Close' }).click();
 
     // Popup should be gone
     await expect(popupTitle).not.toBeVisible();
@@ -68,7 +68,7 @@ test.describe('Wide Popup (About dataset)', () => {
 
   test('background scroll is restored after popup is closed', async ({ page }) => {
     await page.getByText('About EAC mooring array dataset').click();
-    await page.getByAltText('Close').click();
+    await page.getByRole('button', { name: 'Close' }).click();
 
     const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
     expect(bodyOverflow).toBe('');
@@ -78,7 +78,7 @@ test.describe('Wide Popup (About dataset)', () => {
     await page.getByText('About EAC mooring array dataset').click();
 
     // The scrollable body container
-    const scrollContainer = page.locator('.overflow-y-auto').first();
+    const scrollContainer = page.getByTestId('wide-popup-body');
     await expect(scrollContainer).toBeVisible();
 
     const scrollHeight = await scrollContainer.evaluate((el) => el.scrollHeight);

--- a/tests/wide-popup.spec.ts
+++ b/tests/wide-popup.spec.ts
@@ -62,16 +62,16 @@ test.describe('Wide Popup (About dataset)', () => {
   test('background is not scrollable when popup is open', async ({ page }) => {
     await page.getByText('About EAC mooring array dataset').click();
 
-    const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
-    expect(bodyOverflow).toBe('hidden');
+    const bodyPosition = await page.evaluate(() => document.body.style.position);
+    expect(bodyPosition).toBe('fixed');
   });
 
   test('background scroll is restored after popup is closed', async ({ page }) => {
     await page.getByText('About EAC mooring array dataset').click();
     await page.getByRole('button', { name: 'Close' }).click();
 
-    const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
-    expect(bodyOverflow).toBe('');
+    const bodyPosition = await page.evaluate(() => document.body.style.position);
+    expect(bodyPosition).toBe('');
   });
 
   test('popup content is scrollable when content overflows', async ({ page }) => {

--- a/tests/wide-popup.spec.ts
+++ b/tests/wide-popup.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Wide Popup (About dataset)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the EAC Mooring Array product page with the required region
+    await page.goto('/product/eac-mooring-array?region=Brisbane');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('about button is visible in the sidebar', async ({ page }) => {
+    const aboutButton = page.getByText('About EAC mooring array dataset');
+    await expect(aboutButton).toBeVisible();
+  });
+
+  test('clicking about button opens the wide popup', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    // Popup title should be visible
+    const popupTitle = page.getByText('EAC Mooring Array (2012-2022)');
+    await expect(popupTitle).toBeVisible();
+
+    // Close button should be visible
+    const closeButton = page.getByAltText('Close');
+    await expect(closeButton).toBeVisible();
+  });
+
+  test('wide popup contains the article content', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    // Check for key content paragraphs
+    await expect(page.getByText(/The East Australian Current \(EAC\) is the complex/)).toBeVisible();
+
+    // Check for the figure caption
+    await expect(page.getByText(/Figure 1:.*Location of the EAC moorings/)).toBeVisible();
+  });
+
+  test('wide popup can be closed via close button', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    const popupTitle = page.getByText('EAC Mooring Array (2012-2022)');
+    await expect(popupTitle).toBeVisible();
+
+    // Click close button
+    await page.getByAltText('Close').click();
+
+    // Popup should be gone
+    await expect(popupTitle).not.toBeVisible();
+  });
+
+  test('wide popup can be closed by clicking outside', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    const popupTitle = page.getByText('EAC Mooring Array (2012-2022)');
+    await expect(popupTitle).toBeVisible();
+
+    // Click the overlay area (top-left corner, outside the popup card)
+    await page.mouse.click(10, 10);
+
+    await expect(popupTitle).not.toBeVisible();
+  });
+
+  test('background is not scrollable when popup is open', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
+    expect(bodyOverflow).toBe('hidden');
+  });
+
+  test('background scroll is restored after popup is closed', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+    await page.getByAltText('Close').click();
+
+    const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
+    expect(bodyOverflow).toBe('');
+  });
+
+  test('popup content is scrollable when content overflows', async ({ page }) => {
+    await page.getByText('About EAC mooring array dataset').click();
+
+    // The scrollable body container
+    const scrollContainer = page.locator('.overflow-y-auto').first();
+    await expect(scrollContainer).toBeVisible();
+
+    const scrollHeight = await scrollContainer.evaluate((el) => el.scrollHeight);
+    const clientHeight = await scrollContainer.evaluate((el) => el.clientHeight);
+
+    // Content should overflow (scrollHeight > clientHeight)
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+  });
+});


### PR DESCRIPTION
Adds a wide popup for long-form EAC dataset context so users can read background information without overloading the existing summary modal.