### PR TITLE
:sparkles: add /news.php redirect route for legacy URL compatibility

### DIFF
--- a/src/layouts/NewsLayout.tsx
+++ b/src/layouts/NewsLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router';
+
+const NewsLayout: React.FC = () => {
+  return (
+    <div className="mx-auto max-w-7xl overflow-x-hidden px-4 py-12 sm:px-6 lg:px-8">
+      <Outlet />
+    </div>
+  );
+};
+
+export default NewsLayout;

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,7 @@
+import MainLayout from './MainLayout';
+import MapLayout from './MapLayout';
+import DataVisualisationLayout from './DataVisualisationLayout';
+import AboutLayout from './AboutLayout';
+import NewsLayout from './NewsLayout';
+
+export { MainLayout, MapLayout, DataVisualisationLayout, AboutLayout, NewsLayout };

--- a/src/pages/HiddenArchivedNews/HiddenArchivedNews.tsx
+++ b/src/pages/HiddenArchivedNews/HiddenArchivedNews.tsx
@@ -58,10 +58,7 @@ export const HiddenArchivedNews = () => {
   }, []);
 
   return (
-    <div
-      ref={containerRef}
-      className="hiddenArchivedNews mx-auto max-w-7xl overflow-x-hidden px-4 py-12 sm:px-6 lg:px-8 [&_img]:max-w-full"
-    >
+    <div ref={containerRef} className="hiddenArchivedNews [&_img]:max-w-full">
       <div>
         <div className="flex flex-col items-center justify-between gap-y-4 lg:flex-row">
           <h2 className="pl-2">OceanCurrent News</h2>
@@ -10394,3 +10391,5 @@ export const HiddenArchivedNews = () => {
     </div>
   );
 };
+
+export default HiddenArchivedNews;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,5 +3,6 @@ import MapView from './MapView/MapView';
 import DataView from './DataView/DataView';
 import ErrorPage from './ErrorPage/ErrorPage';
 import AboutView from './AboutView/AboutView';
+import HiddenArchivedNews from './HiddenArchivedNews/HiddenArchivedNews';
 
-export { Home, MapView, DataView, ErrorPage, AboutView };
+export { Home, MapView, DataView, ErrorPage, AboutView, HiddenArchivedNews };

--- a/src/routers/routes.tsx
+++ b/src/routers/routes.tsx
@@ -1,11 +1,7 @@
 import { Navigate, type RouteObject } from 'react-router';
-import { Home, MapView, DataView, ErrorPage, AboutView } from '@/pages';
-import MainLayout from '@/layouts/MainLayout';
-import MapLayout from '@/layouts/MapLayout';
-import DataVisualisationLayout from '@/layouts/DataVisualisationLayout';
-import AboutLayout from '@/layouts/AboutLayout';
-import { HiddenArchivedNews } from '@/pages/HiddenArchivedNews/HiddenArchivedNews';
-import { createProductRedirects } from './utils';
+import { Home, MapView, DataView, ErrorPage, AboutView, HiddenArchivedNews } from '@/pages';
+import { MainLayout, MapLayout, DataVisualisationLayout, AboutLayout, NewsLayout } from '@/layouts';
+import { createProductRedirects, NewsPhpRedirect } from './utils';
 import { APP_ROUTES } from './appRoutes';
 
 export { APP_ROUTES };
@@ -78,11 +74,20 @@ const routes: RouteObject[] = [
       },
       {
         path: APP_ROUTES.NEWS,
-        element: <HiddenArchivedNews />,
+        element: <NewsLayout />,
+        children: [
+          {
+            index: true,
+            element: <HiddenArchivedNews />,
+          },
+        ],
       },
     ],
   },
-
+  {
+    path: '/news.php',
+    element: <NewsPhpRedirect />,
+  },
   {
     path: APP_ROUTES.NOT_FOUND,
     element: <ErrorPage />,

--- a/src/routers/utils.tsx
+++ b/src/routers/utils.tsx
@@ -1,7 +1,8 @@
-import { Navigate, type RouteObject } from 'react-router';
+import { Navigate, useLocation, type RouteObject } from 'react-router';
 import { DEFAULT_SUB_PRODUCT_ROUTES } from '@/configs/products/default-routes';
 import { ProductGroupID } from '@/types/product';
 import { findFlatProductById } from '@/utils/product-utils/product';
+import { APP_ROUTES } from './appRoutes';
 
 /**
  * Creates redirect routes for products based on their default sub-product paths
@@ -21,4 +22,9 @@ export const createProductRedirects = (): RouteObject[] => {
   });
 
   return redirects;
+};
+
+export const NewsPhpRedirect = () => {
+  const { hash } = useLocation();
+  return <Navigate to={`${APP_ROUTES.NEWS}${hash}`} replace />;
 };

--- a/tests/news-redirect.spec.ts
+++ b/tests/news-redirect.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('News PHP redirect', () => {
+  test('redirects /news.php to /news', async ({ page }) => {
+    await page.goto('/news.php');
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).toContain('/news');
+    expect(page.url()).not.toContain('/news.php');
+  });
+
+  test('redirects /news.php with hash to /news preserving the hash', async ({ page }) => {
+    await page.goto('/news.php#a-news-title');
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).toContain('/news#a-news-title');
+    expect(page.url()).not.toContain('/news.php');
+  });
+});


### PR DESCRIPTION
Adds a NewsPhpRedirect that preserves hash fragments when redirecting /news.php to /news, introduces NewsLayout for structural consistency, and adds Playwright e2e tests for both redirect cases.