### PR TITLE
:bug: fix climatology reset month on Safari using dayjs

### DIFF
--- a/src/components/ProductMenuBar/ProductMenuBar.test.tsx
+++ b/src/components/ProductMenuBar/ProductMenuBar.test.tsx
@@ -1,36 +1,90 @@
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router';
 import '@/configs/dayjs';
+import { useDateList, useQueryParams, useArgoProductValidQueryParams } from '@/hooks';
+import useProductCheck from '@/stores/product-store/hooks/useProductCheck';
+import { useRegionLatestDates } from '@/services/hooks';
+import { useTidalCurrentPoint } from '@/pages/DataView/product-content/hooks/useTidalCurrentPoint';
 import ProductMenuBar from './ProductMenuBar';
 
-vi.mock('@/components/VideoCreation/VideoCreation', () => {
-  const MockedVideoCreation = () => <div>Download</div>;
-  return { default: MockedVideoCreation };
-});
+vi.mock('@/components/VideoCreation', () => ({
+  default: () => <div>Download</div>,
+}));
+
+vi.mock('../DatePagination', () => ({
+  default: () => <div data-testid="date-pagination" />,
+}));
+
+vi.mock('@/stores/product-store/hooks/useProductCheck', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/stores/product-store/productStore', () => ({
+  default: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ productParams: { productId: 'sixDaySst-climatology' }, isProductImageLoading: false }),
+  ),
+  setIsProductImageLoading: vi.fn(),
+}));
+
+vi.mock('@/stores/product-store/hooks/useProductDateFormat', () => ({
+  default: vi.fn(() => 'MM'),
+}));
+
+vi.mock('@/stores/product-store/hooks/useShowProductOverMap', () => ({
+  useShowProductOverMap: vi.fn(() => true),
+}));
+
+vi.mock('@/stores/current-meters-store/currentMeters', () => ({
+  default: vi.fn(() => ({ date: '', property: '', depth: '', region: '', deploymentPlot: '' })),
+  initialState: {},
+  resetCurrentMetersStore: vi.fn(),
+  setCurrentMetersDate: vi.fn(),
+}));
+
+vi.mock('@/stores/argo-store/argoStore', () => ({
+  default: vi.fn((selector: (state: unknown) => unknown) => selector({ argoProfileCycles: [] })),
+}));
+
+vi.mock('@/services/hooks', () => ({
+  useRegionLatestDates: vi.fn(),
+}));
+
+vi.mock('@/pages/DataView/product-content/hooks/useTidalCurrentPoint', () => ({
+  useTidalCurrentPoint: vi.fn(),
+}));
+
+vi.mock('@/hooks', () => ({
+  useDateList: vi.fn(),
+  useQueryParams: vi.fn(),
+  useArgoProductValidQueryParams: vi.fn(),
+}));
+
+const ALL_MONTHS = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'].map((date) => ({
+  date,
+}));
+
+const renderComponent = () =>
+  render(
+    <MemoryRouter>
+      <ProductMenuBar setShowVideo={vi.fn()} setShowMap={vi.fn()} />
+    </MemoryRouter>,
+  );
 
 describe('ProductMenuBar', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  const renderComponentWithRouter = () => {
-    const setShowVideo = vi.fn();
-    const setShowMap = vi.fn();
-    return render(
-      <MemoryRouter>
-        <ProductMenuBar setShowVideo={setShowVideo} setShowMap={setShowMap} />
-      </MemoryRouter>,
-    );
-  };
-
   it.skip('should render successfully with correct date', () => {
-    renderComponentWithRouter();
+    renderComponent();
     const dateElement = screen.getByText('13 Jun 24');
     expect(dateElement).toBeInTheDocument();
   });
 
   it.skip('should display navigation arrows', () => {
-    renderComponentWithRouter();
+    renderComponent();
     const rightArrow = screen.getByRole('button', {
       name: /right arrow icon/i,
     });
@@ -40,8 +94,83 @@ describe('ProductMenuBar', () => {
   });
 
   it.skip('should display video creation component', () => {
-    renderComponentWithRouter();
+    renderComponent();
     const downloadElement = screen.getByText('Download');
     expect(downloadElement).toBeInTheDocument();
+  });
+
+  describe('handleReset - climatology', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+
+      vi.mocked(useProductCheck).mockReturnValue({
+        isClimatology: true,
+        isArgo: false,
+        isCurrentMeters: false,
+        isCurrentMetersMooredInstrumentArray: false,
+        isMonthlyMeans: false,
+        isEACMooringArray: false,
+        isTidalCurrents: false,
+        isSealCtd: false,
+        isSealCtdTags: false,
+        isSurfaceWaves: false,
+        isSurfaceWavesBuoyTimeseries: false,
+        isRegionRequired: true,
+      } as ReturnType<typeof useProductCheck>);
+
+      vi.mocked(useArgoProductValidQueryParams).mockReturnValue({
+        isArgoValid: false,
+      } as ReturnType<typeof useArgoProductValidQueryParams>);
+
+      vi.mocked(useRegionLatestDates).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+      } as ReturnType<typeof useRegionLatestDates>);
+
+      vi.mocked(useTidalCurrentPoint).mockReturnValue({
+        isTidalCurrentsPointSelected: false,
+      } as ReturnType<typeof useTidalCurrentPoint>);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('resets to the month matching the current system month', () => {
+      vi.setSystemTime(new Date('2024-04-15')); // April → month 3 (0-indexed)
+      const mockUpdateQueryParams = vi.fn();
+      vi.mocked(useQueryParams).mockReturnValue({
+        updateQueryParams: mockUpdateQueryParams,
+        updateQueryParamsAndNavigate: vi.fn(),
+      } as unknown as ReturnType<typeof useQueryParams>);
+      vi.mocked(useDateList).mockReturnValue({
+        isLoading: false,
+        dateList: ALL_MONTHS,
+      } as ReturnType<typeof useDateList>);
+
+      renderComponent();
+      fireEvent.click(screen.getByRole('button', { name: 'Reset to latest date' }));
+
+      expect(mockUpdateQueryParams).toHaveBeenCalledWith({ date: '04' });
+    });
+
+    it('falls back to the last date in the list when the current month is not available', () => {
+      vi.setSystemTime(new Date('2024-04-15')); // April
+      const mockUpdateQueryParams = vi.fn();
+      vi.mocked(useQueryParams).mockReturnValue({
+        updateQueryParams: mockUpdateQueryParams,
+        updateQueryParamsAndNavigate: vi.fn(),
+      } as unknown as ReturnType<typeof useQueryParams>);
+      // dateList without April ('04')
+      vi.mocked(useDateList).mockReturnValue({
+        isLoading: false,
+        dateList: ALL_MONTHS.filter((d) => d.date !== '04'),
+      } as ReturnType<typeof useDateList>);
+
+      renderComponent();
+      fireEvent.click(screen.getByRole('button', { name: 'Reset to latest date' }));
+
+      expect(mockUpdateQueryParams).toHaveBeenCalledWith({ date: '12' });
+    });
   });
 });

--- a/src/components/ProductMenuBar/ProductMenuBar.tsx
+++ b/src/components/ProductMenuBar/ProductMenuBar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import dayjs from 'dayjs';
 import { useSearchParams } from 'react-router';
 import { useDateList, useQueryParams, useArgoProductValidQueryParams } from '@/hooks';
 import { Dropdown, Button, ShareButton } from '@/components/Shared';
@@ -12,6 +13,7 @@ import useCurrentMetersStore, {
 } from '@/stores/current-meters-store/currentMeters';
 import useProductStore, { setIsProductImageLoading } from '@/stores/product-store/productStore';
 import useProductDateFormat from '@/stores/product-store/hooks/useProductDateFormat';
+import { DateFormat } from '@/types/date';
 import { currentMeterSYearOptionsData } from '@/data/current-meter/sidebarOptions';
 import { CurrentMetersSubProductsKey } from '@/constants/currentMeters';
 import useArgoStore from '@/stores/argo-store/argoStore';
@@ -94,12 +96,11 @@ const ProductMenuBar: React.FC<ProductMenuBarProps> = ({
     }
 
     const latestDate = dateList?.[dateList.length - 1]?.date;
-
     if (isClimatology) {
-      const currentMonth = new Date().getMonth() + 1;
+      const currentMonth = dayjs().month() + 1;
       const climatologyDate =
         dateList.find((dateItem) => {
-          const dateMonth = new Date(dateItem.date).getMonth() + 1;
+          const dateMonth = dayjs(dateItem.date, DateFormat.MONTH_ONLY).month() + 1;
           return dateMonth === currentMonth;
         })?.date || latestDate;
 

--- a/src/components/ProductMenuBar/ProductMenuBar.tsx
+++ b/src/components/ProductMenuBar/ProductMenuBar.tsx
@@ -100,7 +100,9 @@ const ProductMenuBar: React.FC<ProductMenuBarProps> = ({
       const currentMonth = dayjs().month() + 1;
       const climatologyDate =
         dateList.find((dateItem) => {
-          const dateMonth = dayjs(dateItem.date, DateFormat.MONTH_ONLY).month() + 1;
+          const parsedMonth = dayjs(dateItem.date, DateFormat.MONTH_ONLY, true);
+          if (!parsedMonth.isValid()) return false;
+          const dateMonth = parsedMonth.month() + 1;
           return dateMonth === currentMonth;
         })?.date || latestDate;
 


### PR DESCRIPTION
Safari cannot parse the MM-format date strings with native Date. Replaced with dayjs and an explicit format to match the current month reliably. Added unit tests covering the reset and the fallback-to-last-date behaviour.