### PR TITLE
:bug: prevent back-button trap on current meters product page

### DIFF
--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -5,7 +5,13 @@ import { ProductSidebarText } from '@/constants/textConstant';
 import useDateStore from '@/stores/date-store/dateStore';
 import { useMultipleRegionLatestDates } from '@/services/hooks';
 import { setProductId } from '@/stores/product-store/productStore';
-import { setCurrentMetersDate, setDepth, setProperty, setRegion } from '@/stores/current-meters-store/currentMeters';
+import {
+  setCurrentMetersDate,
+  setDepth,
+  setDeploymentPlot,
+  setProperty,
+  setRegion,
+} from '@/stores/current-meters-store/currentMeters';
 import {
   CurrentMetersDepth,
   CurrentMetersProperty,
@@ -90,6 +96,14 @@ const ProductSideBar: React.FC = () => {
         date: allTime,
         depth: CurrentMetersDepth.ONE,
       };
+    }
+
+    // Switching to moored-instrument-array means returning to the region
+    // overview, so any plot carried over from another sub-product would
+    // point at a deployment that does not exist here and would fail to load.
+    if (isCurrentMeters && subProductPath === mooredInstrumentArrayPath) {
+      setDeploymentPlot('');
+      updateParam = { deploymentPlot: null };
     }
 
     if (isSealCtd) {

--- a/src/components/DataVisualisationSidebar/components/CurrentMetersFilters.tsx
+++ b/src/components/DataVisualisationSidebar/components/CurrentMetersFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { Button, Dropdown } from '@/components/Shared';
 import useCurrentMetersStore, {
@@ -26,6 +26,7 @@ import {
 import { SubProduct } from '@/types/product';
 import { getDeploymentPlotsBySubProduct } from '@/components/Map/utils/mapUtils';
 import { currentMetersMapDataPointsFlat } from '@/data/current-meter/mapDataPoints';
+import omitEmptyParams from '@/hooks/useQueryParams/omitEmptyParams';
 
 interface CurrentMetersFiltersProp {
   subProduct: SubProduct | null;
@@ -52,16 +53,7 @@ const CurrentMetersFilters: React.FC<CurrentMetersFiltersProp> = ({ subProduct }
   const subProductKey = subProduct?.key;
   const isMooredInstrumentArraySubProduct = subProductKey === CurrentMetersSubProductsKey.MOORED_INSTRUMENT_ARRAY;
   const allTimeOption = currentMeterSYearOptionsData[0].id;
-
-  const stdParams = useMemo(() => {
-    return {
-      depth,
-      property,
-      region,
-      date,
-      deploymentPlot,
-    };
-  }, [date, deploymentPlot, depth, property, region]);
+  const prevSubProductKeyRef = useRef(subProductKey);
 
   // update deployment plots list and default option when switching sub products
   useEffect(() => {
@@ -70,16 +62,47 @@ const CurrentMetersFilters: React.FC<CurrentMetersFiltersProp> = ({ subProduct }
     const plotsList = getDeploymentPlotsBySubProduct(subProductKey);
     setDeploymentPlotOptions(plotsList);
 
-    if (!plotsList.some((plot) => plot.id === deploymentPlot)) {
-      if (!isMooredInstrumentArraySubProduct) {
-        setDeploymentPlot(plotsList[0].id);
-        setSearchParams({ ...stdParams, deploymentPlot: plotsList[0].id });
-      } else {
-        setDeploymentPlot('');
-        setSearchParams({ ...stdParams, deploymentPlot: '' });
-      }
+    // MIA's plot list aggregates every sub-product's plots, so a Shelf plot
+    // carried over in the URL still passes `plotsList.some(...)`. Detect the
+    // sub-product transition explicitly and force the overview state. Skip on
+    // the first run where prev is undefined to preserve MIA deeplinks.
+    const justSwitchedToMooredInstrumentArray =
+      isMooredInstrumentArraySubProduct &&
+      prevSubProductKeyRef.current !== undefined &&
+      prevSubProductKeyRef.current !== subProductKey;
+    prevSubProductKeyRef.current = subProductKey;
+
+    if (justSwitchedToMooredInstrumentArray) {
+      setDeploymentPlot('');
+      setSearchParams(omitEmptyParams({ depth, property, region, date }), { replace: true });
+      return;
     }
-  }, [deploymentPlot, isMooredInstrumentArraySubProduct, setSearchParams, stdParams, subProductKey]);
+
+    const isPlotValid = isMooredInstrumentArraySubProduct
+      ? deploymentPlot === '' || plotsList.some((plot) => plot.id === deploymentPlot)
+      : plotsList.some((plot) => plot.id === deploymentPlot);
+
+    if (isPlotValid) return;
+
+    if (!isMooredInstrumentArraySubProduct) {
+      setDeploymentPlot(plotsList[0].id);
+      setSearchParams(omitEmptyParams({ depth, property, region, date, deploymentPlot: plotsList[0].id }), {
+        replace: true,
+      });
+    } else {
+      setDeploymentPlot('');
+      setSearchParams(omitEmptyParams({ depth, property, region, date }), { replace: true });
+    }
+  }, [
+    deploymentPlot,
+    isMooredInstrumentArraySubProduct,
+    setSearchParams,
+    depth,
+    property,
+    region,
+    date,
+    subProductKey,
+  ]);
 
   // update store based on params
   useEffect(() => {
@@ -120,7 +143,7 @@ const CurrentMetersFilters: React.FC<CurrentMetersFiltersProp> = ({ subProduct }
   const handleRegionChange = (id: string) => {
     setRegion(id as CurrentMetersRegion);
     setDeploymentPlot('');
-    setSearchParams({ ...stdParams, region: id, deploymentPlot: '' });
+    setSearchParams(omitEmptyParams({ depth, property, region: id, date }));
   };
 
   const handleDeploymentPlotChange = (id: string) => {
@@ -143,23 +166,25 @@ const CurrentMetersFilters: React.FC<CurrentMetersFiltersProp> = ({ subProduct }
     }
 
     setDeploymentPlot(id as CurrentMetersDeploymentPlotNames);
-    setSearchParams({
-      region: correctRegion,
-      deploymentPlot: id,
-      date: allTimeOption,
-      property: CurrentMetersProperty.vrms,
-      depth: CurrentMetersDepth.ONE,
-    });
+    setSearchParams(
+      omitEmptyParams({
+        region: correctRegion,
+        deploymentPlot: id,
+        date: allTimeOption,
+        property: CurrentMetersProperty.vrms,
+        depth: CurrentMetersDepth.ONE,
+      }),
+    );
   };
 
   const handleDepthChange = (id: string) => {
     setDepth(id as CurrentMetersDepth);
-    setSearchParams({ ...stdParams, depth: id });
+    setSearchParams(omitEmptyParams({ depth: id, property, region, date, deploymentPlot }));
   };
 
   const handlePropertyChange = (id: string) => {
     setProperty(id as CurrentMetersProperty);
-    setSearchParams({ ...stdParams, property: id });
+    setSearchParams(omitEmptyParams({ depth, property: id, region, date, deploymentPlot }));
   };
 
   return (

--- a/src/components/Map/BasicMap.tsx
+++ b/src/components/Map/BasicMap.tsx
@@ -64,7 +64,11 @@ const BasicMap: React.FC<BasicMapProps> = ({
   useResizeObserver((mapWrapperRef as React.RefObject<HTMLDivElement>) || null, handleMapResize);
 
   useEffect(() => {
+    if (isMiniMap) return;
     resetCurrentMetersStore();
+  }, [isMiniMap]);
+
+  useEffect(() => {
     if (isMobile) {
       patchMapViewState(initialMobileMapViewState.mapViewState);
     }

--- a/src/hooks/useQueryParams/omitEmptyParams.test.ts
+++ b/src/hooks/useQueryParams/omitEmptyParams.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import omitEmptyParams from './omitEmptyParams';
+
+describe('omitEmptyParams', () => {
+  it('drops empty-string, null, and undefined values', () => {
+    expect(
+      omitEmptyParams({
+        keep: 'value',
+        dropEmpty: '',
+        dropNull: null,
+        dropUndefined: undefined,
+      }),
+    ).toEqual({ keep: 'value' });
+  });
+
+  it('returns an empty object when every value is empty or nullish', () => {
+    expect(omitEmptyParams({ a: '', b: null, c: undefined })).toEqual({});
+  });
+
+  it('preserves all keys when every value is a non-empty string', () => {
+    const params = { region: '01_Aust', depth: '1', property: 'vrms', date: '0000' };
+    expect(omitEmptyParams(params)).toEqual(params);
+  });
+
+  it('treats whitespace-only strings as non-empty', () => {
+    expect(omitEmptyParams({ note: ' ' })).toEqual({ note: ' ' });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(omitEmptyParams({})).toEqual({});
+  });
+
+  it('does not mutate the input object', () => {
+    const params = { keep: 'value', drop: '' };
+    omitEmptyParams(params);
+    expect(params).toEqual({ keep: 'value', drop: '' });
+  });
+});

--- a/src/hooks/useQueryParams/omitEmptyParams.ts
+++ b/src/hooks/useQueryParams/omitEmptyParams.ts
@@ -1,0 +1,12 @@
+// TODO: Merge this into `useQueryParams` so the codebase has one consistent
+// convention for stripping query params. `useQueryParams.buildNewSearchParams`
+// currently uses `null` as the explicit delete sentinel and keeps `''` as a
+// set-with-empty-value, while this helper drops any empty/nullish value. Once
+// the call sites (CurrentMetersFilters, DataImageWithCurrentMetersMap) are
+// migrated to `useQueryParams`, this file can be deleted.
+const omitEmptyParams = (params: Record<string, string | null | undefined>): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(params).filter((entry): entry is [string, string] => entry[1] !== '' && entry[1] != null),
+  );
+
+export default omitEmptyParams;

--- a/src/pages/DataView/data-image/DataImageWithCurrentMetersMap.tsx
+++ b/src/pages/DataView/data-image/DataImageWithCurrentMetersMap.tsx
@@ -16,6 +16,7 @@ import { useResizeObserver } from '@/hooks';
 import useProductStore, { setIsProductImageLoading } from '@/stores/product-store/productStore';
 import { LinearProgress } from '@/components/Shared';
 import { cn } from '@/utils/classname-util/cn';
+import omitEmptyParams from '@/hooks/useQueryParams/omitEmptyParams';
 
 type DataImageWithCurrentMetersMapProps = {
   mainProduct: Product | null;
@@ -78,24 +79,27 @@ const DataImageWithCurrentMetersMap: React.FC<DataImageWithCurrentMetersMapProps
 
     if (type === 'region' && code) {
       setRegion(code);
-      setSearchParams({
-        property: CurrentMetersProperty.vrms,
-        depth: CurrentMetersDepth.ONE,
-        region: code,
-        date: date,
-        deploymentPlot: '',
-      });
+      setSearchParams(
+        omitEmptyParams({
+          property: CurrentMetersProperty.vrms,
+          depth: CurrentMetersDepth.ONE,
+          region: code,
+          date: date,
+        }),
+      );
     }
 
     if (type === 'plot' || type === 'text') {
       setDeploymentPlot(name as CurrentMetersDeploymentPlotNames);
-      setSearchParams({
-        property: CurrentMetersProperty.vrms,
-        depth: CurrentMetersDepth.ONE,
-        region: getRegion,
-        date: currentMeterSYearOptionsData[0].id, // all time
-        deploymentPlot: name,
-      });
+      setSearchParams(
+        omitEmptyParams({
+          property: CurrentMetersProperty.vrms,
+          depth: CurrentMetersDepth.ONE,
+          region: getRegion,
+          date: currentMeterSYearOptionsData[0].id, // all time
+          deploymentPlot: name,
+        }),
+      );
     }
   };
 

--- a/src/pages/DataView/product-content/ProductContent.tsx
+++ b/src/pages/DataView/product-content/ProductContent.tsx
@@ -271,12 +271,12 @@ const ProductContent: React.FC = () => {
     );
   }
 
-  // Current meters
+  // Use the store (not the URL) as source of truth — a stale URL deploymentPlot
+  // would otherwise route to the plot view with an empty store value.
   if (productChecks.isCurrentMeters) {
     if (
       subProduct?.key === CurrentMetersSubProductsKey.MOORED_INSTRUMENT_ARRAY &&
-      currentMetersParams.deploymentPlot === '' &&
-      !hasSelectedParams.deploymentPlot
+      currentMetersParams.deploymentPlot === ''
     ) {
       return (
         <DataImageWithCurrentMetersMap

--- a/tests/current-meters.spec.ts
+++ b/tests/current-meters.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Current Meters Tests', () => {
+  test('back button returns to map view after region polygon click', async ({ page }) => {
+    // Issue #8441: clicking a region polygon from /map/current-meters/...
+    // used to push extra history entries via setSearchParams during the
+    // fix-up effect, trapping the user when they pressed back.
+    await page.goto('/map/current-meters/moored-instrument-array');
+    await page.waitForLoadState('networkidle');
+
+    const mapCanvas = page.locator('.mapboxgl-canvas').first();
+    await expect(mapCanvas).toBeVisible();
+    // Wait for mapbox layers to render before clicking.
+    await page.waitForTimeout(2000);
+
+    // The map page renders region polygons as mapbox layers on canvas, so we
+    // click multiple points until the URL navigates to a product page.
+    const box = await mapCanvas.boundingBox();
+    if (!box) throw new Error('Map canvas not visible');
+
+    const clickPoints = [
+      { x: 0.5, y: 0.5 },
+      { x: 0.4, y: 0.4 },
+      { x: 0.6, y: 0.6 },
+      { x: 0.3, y: 0.5 },
+      { x: 0.5, y: 0.3 },
+      { x: 0.7, y: 0.5 },
+      { x: 0.35, y: 0.35 },
+      { x: 0.65, y: 0.65 },
+    ];
+    for (const point of clickPoints) {
+      await page.mouse.click(box.x + box.width * point.x, box.y + box.height * point.y);
+      try {
+        await page.waitForURL(/\/product\/current-meters\//, { timeout: 2000 });
+        break;
+      } catch {
+        await page.waitForTimeout(200);
+      }
+    }
+    expect(page.url()).toMatch(/\/product\/current-meters\//);
+
+    // Press the browser back button — it should return us to the map view
+    // on the first press (no history pollution).
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+    expect(page.url()).toMatch(/\/map\/current-meters\/moored-instrument-array/);
+  });
+
+  test('moored-instrument-array product URL has no deploymentPlot when no plot is selected', async ({ page }) => {
+    // The previous bug left an empty `&deploymentPlot=` in the URL on the
+    // moored-instrument-array sub-product because the overview map is the
+    // default. omitEmptyParams + the fix-up effect should keep the URL clean.
+    await page.goto('/product/current-meters/moored-instrument-array?region=01_Aust&date=0000');
+    await page.waitForLoadState('networkidle');
+    // Allow the URL-to-store sync and fix-up effects to settle.
+    await page.waitForTimeout(1500);
+
+    expect(page.url()).not.toContain('deploymentPlot=');
+  });
+
+  test('switching from shelf to moored-instrument-array drops the stale deploymentPlot', async ({ page }) => {
+    // Shelf's fix-up effect auto-populates the first Shelf plot in the URL.
+    // When the user switches back to moored-instrument-array, the stale plot
+    // must be cleared so the overview map is shown instead of the plot view.
+    await page.goto('/product/current-meters/shelf');
+    await page.waitForLoadState('networkidle');
+
+    // Wait for the Shelf fix-up to write a deploymentPlot into the URL.
+    await page.waitForURL(/deploymentPlot=/, { timeout: 5000 });
+    expect(page.url()).toContain('deploymentPlot=');
+
+    // Click the "Moored Instrument Array" sub-product button.
+    const miaButton = page.getByRole('button', { name: /moored instrument array/i }).first();
+    await expect(miaButton).toBeVisible();
+    await miaButton.click();
+
+    await page.waitForURL(/\/product\/current-meters\/moored-instrument-array/, { timeout: 5000 });
+    await page.waitForLoadState('networkidle');
+    // Allow the fix-up transition guard to run.
+    await page.waitForTimeout(800);
+
+    expect(page.url()).not.toContain('deploymentPlot=');
+  });
+
+  test('direct URL to moored-instrument-array with deploymentPlot preserves the plot', async ({ page }) => {
+    // Sanity check: BasicMap's mount effect previously reset the current
+    // meters store every time the sidebar mini map mounted. With the
+    // isMiniMap guard, a direct URL that includes a plot must round-trip cleanly.
+    await page.goto(
+      '/product/current-meters/moored-instrument-array?region=01_Aust&date=0000&depth=1&property=vrms&deploymentPlot=NWSLYN',
+    );
+    await page.waitForLoadState('networkidle');
+    // Let the mini map's BasicMap mount effect and the URL-to-store sync run.
+    await page.waitForTimeout(1500);
+
+    expect(page.url()).toContain('deploymentPlot=NWSLYN');
+  });
+});

--- a/tests/current-meters.spec.ts
+++ b/tests/current-meters.spec.ts
@@ -6,7 +6,6 @@ test.describe('Current Meters Tests', () => {
     // used to push extra history entries via setSearchParams during the
     // fix-up effect, trapping the user when they pressed back.
     await page.goto('/map/current-meters/moored-instrument-array');
-    await page.waitForLoadState('networkidle');
 
     const mapCanvas = page.locator('.mapboxgl-canvas').first();
     await expect(mapCanvas).toBeVisible();
@@ -42,7 +41,7 @@ test.describe('Current Meters Tests', () => {
     // Press the browser back button — it should return us to the map view
     // on the first press (no history pollution).
     await page.goBack();
-    await page.waitForLoadState('networkidle');
+    await page.waitForURL(/\/map\/current-meters\/moored-instrument-array/);
     expect(page.url()).toMatch(/\/map\/current-meters\/moored-instrument-array/);
   });
 
@@ -51,9 +50,10 @@ test.describe('Current Meters Tests', () => {
     // moored-instrument-array sub-product because the overview map is the
     // default. omitEmptyParams + the fix-up effect should keep the URL clean.
     await page.goto('/product/current-meters/moored-instrument-array?region=01_Aust&date=0000');
-    await page.waitForLoadState('networkidle');
-    // Allow the URL-to-store sync and fix-up effects to settle.
-    await page.waitForTimeout(1500);
+    // Wait for the product sidebar to mount so its fix-up effect has run.
+    await expect(page.getByText('Region', { exact: true })).toBeVisible();
+    // Give the fix-up effect a small window to write to the URL if it intends to.
+    await page.waitForTimeout(500);
 
     expect(page.url()).not.toContain('deploymentPlot=');
   });
@@ -63,8 +63,6 @@ test.describe('Current Meters Tests', () => {
     // When the user switches back to moored-instrument-array, the stale plot
     // must be cleared so the overview map is shown instead of the plot view.
     await page.goto('/product/current-meters/shelf');
-    await page.waitForLoadState('networkidle');
-
     // Wait for the Shelf fix-up to write a deploymentPlot into the URL.
     await page.waitForURL(/deploymentPlot=/, { timeout: 5000 });
     expect(page.url()).toContain('deploymentPlot=');
@@ -74,11 +72,10 @@ test.describe('Current Meters Tests', () => {
     await expect(miaButton).toBeVisible();
     await miaButton.click();
 
-    await page.waitForURL(/\/product\/current-meters\/moored-instrument-array/, { timeout: 5000 });
-    await page.waitForLoadState('networkidle');
-    // Allow the fix-up transition guard to run.
-    await page.waitForTimeout(800);
-
+    await page.waitForURL(
+      (url) => url.pathname.endsWith('/moored-instrument-array') && !url.search.includes('deploymentPlot='),
+      { timeout: 5000 },
+    );
     expect(page.url()).not.toContain('deploymentPlot=');
   });
 
@@ -89,9 +86,10 @@ test.describe('Current Meters Tests', () => {
     await page.goto(
       '/product/current-meters/moored-instrument-array?region=01_Aust&date=0000&depth=1&property=vrms&deploymentPlot=NWSLYN',
     );
-    await page.waitForLoadState('networkidle');
-    // Let the mini map's BasicMap mount effect and the URL-to-store sync run.
-    await page.waitForTimeout(1500);
+    // Wait for the product sidebar to mount.
+    await expect(page.getByText('Region', { exact: true })).toBeVisible();
+    // Give the BasicMap mount effect a window to (incorrectly) clear it.
+    await page.waitForTimeout(800);
 
     expect(page.url()).toContain('deploymentPlot=NWSLYN');
   });

--- a/tests/news-redirect.spec.ts
+++ b/tests/news-redirect.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('News PHP redirect', () => {
   test('redirects /news.php to /news', async ({ page }) => {
     await page.goto('/news.php');
-    await page.waitForLoadState('networkidle');
+    await page.waitForURL(/\/news($|\?|#)/);
 
     expect(page.url()).toContain('/news');
     expect(page.url()).not.toContain('/news.php');
@@ -11,7 +11,7 @@ test.describe('News PHP redirect', () => {
 
   test('redirects /news.php with hash to /news preserving the hash', async ({ page }) => {
     await page.goto('/news.php#a-news-title');
-    await page.waitForLoadState('networkidle');
+    await page.waitForURL(/\/news#a-news-title$/);
 
     expect(page.url()).toContain('/news#a-news-title');
     expect(page.url()).not.toContain('/news.php');


### PR DESCRIPTION
Use replace:true in the deployment-plot fix-up effect so it no longer pushes a new history entry on every URL change. Add omitEmptyParams helper to drop empty deploymentPlot from the URL.