### PR TITLE
:bug: fall back to useDate when Argo cycle absent from API

### DIFF
--- a/src/pages/DataView/product-content/ProductContent.test.tsx
+++ b/src/pages/DataView/product-content/ProductContent.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -91,6 +91,37 @@ describe('ProductContent — Argo profile cycles query states', () => {
     vi.mocked(fetchArgoProfileCyclesByWmoId).mockRejectedValue(new Error('Network error'));
 
     renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByAltText('not found icon')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ProductContent — Argo cycle absent from API data (scheduled task lag)', () => {
+  beforeEach(() => {
+    const mock = mockArgoData as unknown as ReturnType<typeof useProductContentData>;
+    vi.mocked(useProductContentData).mockReturnValue(mock);
+    // API returns cycles, but not the one the user selected (cycle '001')
+    vi.mocked(fetchArgoProfileCyclesByWmoId).mockResolvedValue([
+      { cycle: '999', date: '20241231', filename: 'other.png' },
+    ]);
+  });
+
+  it('renders the image using fallback date when cycle is missing from API data', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByAltText('product')).toBeInTheDocument();
+    });
+    expect(screen.queryByAltText('not found icon')).not.toBeInTheDocument();
+  });
+
+  it('shows ErrorImage when cycle is missing from API data and the image 404s', async () => {
+    renderComponent();
+
+    const img = await waitFor(() => screen.getByAltText('product'));
+    fireEvent.error(img);
 
     await waitFor(() => {
       expect(screen.getByAltText('not found icon')).toBeInTheDocument();

--- a/src/pages/DataView/product-content/ProductContent.tsx
+++ b/src/pages/DataView/product-content/ProductContent.tsx
@@ -97,13 +97,10 @@ const ProductContent: React.FC = () => {
       // Video-disabled products with specialized params
       switch (true) {
         case isArgo: {
-          const { date: cycleDate } = argoProfileCyclesData!.find(({ cycle }) => cycle === argoParams.cycle)!;
-          return buildArgoImageUrl(
-            argoParams.worldMeteorologicalOrgId,
-            dayjs(cycleDate),
-            argoParams.cycle,
-            argoParams.depth,
-          );
+          // Fall back to useDate if the cycle isn't in the API data yet (scheduled task lag).
+          const found = argoProfileCyclesData?.find(({ cycle }) => cycle === argoParams.cycle);
+          const cycleDate = found ? dayjs(found.date) : useDate;
+          return buildArgoImageUrl(argoParams.worldMeteorologicalOrgId, cycleDate, argoParams.cycle, argoParams.depth);
         }
         case isCurrentMeters:
           return buildCurrentMetersMapImageUrl(
@@ -205,10 +202,6 @@ const ProductContent: React.FC = () => {
 
   if (isArgo && !isArgoProfileCyclesSuccess) {
     return isArgoProfileCyclesError ? <ErrorImage date={useDate} productId="argo" /> : <Loading />;
-  }
-
-  if (isArgo && !argoProfileCyclesData?.find(({ cycle }) => cycle === argoParams.cycle)) {
-    return <ErrorImage date={useDate} productId="argo" />;
   }
 
   if (isSurfaceWavesBuoyTimeseries && !hasSelectedParams.buoyRegion) {


### PR DESCRIPTION
The backend scheduled task may not yet reflect images recently added
to the file server. Blocking on cycle presence caused a false error
screen; now we attempt to load with useDate as a fallback and let the
image 404 handler surface the error only if the file truly does not exist.