### PR TITLE
:sparkles: add SWOT legend for swotGsla SSH and MDT products

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "files.insertFinalNewline": true,
   "cSpell.words": [
     "AATAMS",
+    "adcp",
     "ANFOG",
     "ANMN",
     "Anom",

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ Welcome to our project, aimed at redefining the user experience and accessibilit
 
 ### Prerequisites
 
-- Node.js 24 or later (you can use [nvm](https://github.com/nvm-sh/nvm) — run `nvm use` to switch to the version in `.nvmrc`).
-- Yarn 4.14.1
+- Node.js 24 or later — use a version manager (e.g. fnm, nvm) with the `.nvmrc` file.
 
 ### Installation
 
 1. **Clone the repository:**
 
 ```bash
-git clone <repository-url>
+# SSH
+git clone git@github.com:aodn/ocean-current-frontend.git
+# HTTPS
+git clone https://github.com/aodn/ocean-current-frontend.git
 ```
 
 2. **Navigate to the project directory:**
@@ -34,13 +36,19 @@ cd ocean-current-frontend
 cp .env.local.example .env.local
 ```
 
-4. **Install the project dependencies:**
+4. **Enable Yarn via [Corepack](https://nodejs.org/api/corepack.html) (bundled with Node.js):**
+
+```bash
+corepack enable
+```
+
+5. **Install the project dependencies:**
 
 ```bash
 yarn install
 ```
 
-5. **Run the app in dev mode:**
+6. **Run the app in dev mode:**
 
 ```bash
 yarn dev

--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -24,9 +24,8 @@ import { ProductID } from '@/types/product';
 import useProductCheck from '@/stores/product-store/hooks/useProductCheck';
 import { useShowProductOverMap } from '@/stores/product-store/hooks/useShowProductOverMap';
 import { useQueryParams } from '@/hooks';
-import { findLeafFlatProductById } from '@/utils/product-utils/product';
+import { findLeafFlatProductById, getProductLegend } from '@/utils/product-utils/product';
 import { DEFAULT_SUB_PRODUCT_ROUTES } from '@/configs/products/default-routes';
-import { getProductLegend } from '@/constants/productLegends';
 import Legend from './components/Legend';
 import MiniMap from './components/MiniMap';
 import ProductDropdown from './components/ProductDropdown';
@@ -172,7 +171,7 @@ const ProductSideBar: React.FC = () => {
 
         {productLegendItems && productLegendItems.length > 0 && (
           <CollapsibleSection title={ProductSidebarText.LEGEND}>
-            <Legend legendItems={productLegendItems} />
+            <Legend legendItems={productLegendItems} title={mainProduct.title} />
           </CollapsibleSection>
         )}
       </div>

--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -171,7 +171,7 @@ const ProductSideBar: React.FC = () => {
 
         {productLegendItems && productLegendItems.length > 0 && (
           <CollapsibleSection title={ProductSidebarText.LEGEND}>
-            <Legend legendItems={productLegendItems} title={mainProduct.title} />
+            <Legend legendItems={productLegendItems} title={productInfo?.title ?? mainProduct.title} />
           </CollapsibleSection>
         )}
       </div>

--- a/src/components/DataVisualisationSidebar/components/Legend.test.tsx
+++ b/src/components/DataVisualisationSidebar/components/Legend.test.tsx
@@ -56,6 +56,25 @@ describe('Legend', () => {
     expect(screen.getByText(/The latest ASL \(NRT00\) map/)).toBeInTheDocument();
   });
 
+  it('defaults the popup title to "Legend"', () => {
+    render(<Legend legendItems={[itemWithShape]} />);
+
+    // closed by default
+    expect(screen.queryByText('Legend')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Click for more information'));
+
+    expect(screen.getByText('Legend')).toBeInTheDocument();
+  });
+
+  it('uses the provided title for the popup', () => {
+    render(<Legend legendItems={[itemWithShape]} title="SWOT and GSLA" />);
+
+    fireEvent.click(screen.getByText('Click for more information'));
+
+    expect(screen.getByText('SWOT and GSLA')).toBeInTheDocument();
+  });
+
   it('matches snapshot', () => {
     const { container } = render(<Legend legendItems={[itemWithShape, itemWithLabelOnly, itemDescriptionOnly]} />);
     expect(container).toMatchSnapshot();

--- a/src/components/DataVisualisationSidebar/components/Legend.tsx
+++ b/src/components/DataVisualisationSidebar/components/Legend.tsx
@@ -5,9 +5,10 @@ import LegendPopupBody from './LegendPopupBody';
 
 interface LegendProps {
   legendItems?: LegendItem[] | null;
+  title?: string;
 }
 
-const Legend: React.FC<LegendProps> = ({ legendItems }) => {
+const Legend: React.FC<LegendProps> = ({ legendItems, title = 'Legend' }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
   const handlePopup = () => {
@@ -22,7 +23,7 @@ const Legend: React.FC<LegendProps> = ({ legendItems }) => {
 
   return (
     <div className="pb-4">
-      <div className="mb-6 mt-2 grid grid-cols-2 gap-x-1 gap-y-4 px-3">
+      <div className="mt-2 mb-6 grid grid-cols-2 gap-x-1 gap-y-4 px-3">
         {sidebarItems.map((item, index) => (
           <div key={`${item.label}-${index}`} className="flex items-center">
             <div className="mr-3 flex shrink-0 items-center justify-center">{item.shape}</div>
@@ -35,7 +36,7 @@ const Legend: React.FC<LegendProps> = ({ legendItems }) => {
       </Button>
 
       <Popup
-        title="Legend"
+        title={title}
         body={() => <LegendPopupBody legendItems={legendItems} />}
         isOpen={isPopupOpen}
         onClose={handlePopup}

--- a/src/components/DataVisualisationSidebar/components/__snapshots__/Legend.test.tsx.snap
+++ b/src/components/DataVisualisationSidebar/components/__snapshots__/Legend.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Legend > matches snapshot 1`] = `
     class="pb-4"
   >
     <div
-      class="mb-6 mt-2 grid grid-cols-2 gap-x-1 gap-y-4 px-3"
+      class="mt-2 mb-6 grid grid-cols-2 gap-x-1 gap-y-4 px-3"
     >
       <div
         class="flex items-center"

--- a/src/constants/productLegends.tsx
+++ b/src/constants/productLegends.tsx
@@ -147,7 +147,6 @@ const SST_MAP_LEGENDS: LegendItem[] = [
   COMMON_LEGEND_ITEMS.mooring,
 ];
 
-// SWOT legend (legacy 97_swot.php getLegend + dr_swot_legend.html legend text).
 // Sidebar shows items with a shape; the popup also shows the description-only
 // isobaths and Sea Surface Height entries.
 const SWOT_LEGENDS: LegendItem[] = [

--- a/src/constants/productLegends.tsx
+++ b/src/constants/productLegends.tsx
@@ -82,6 +82,19 @@ const COMMON_LEGEND_ITEMS = {
     ),
     description: 'Drifter buoy locations showing surface current trajectories.',
   },
+  adcp: {
+    icon: 'arrow-up',
+    label: 'ADCP velocity',
+    shape: (
+      <div className="flex h-3 w-3 items-center">
+        <div className="bg-imos-dodger-blue relative h-0.5 w-3">
+          <div className="border-imos-dodger-blue absolute -top-[3px] right-0 h-2 w-2 rotate-45 border-t-2 border-r-2" />
+        </div>
+      </div>
+    ),
+    description:
+      'Velocity of the current as measured by moored ADCPs (Acoustic Doppler Current Profilers). The velocity shown is the averaged velocity from the surface to the bottom, and averaged over 25 hours (centred at t0), to remove the effect of tides. Location and velocity are indicated with a blue arrow head.',
+  },
 
   // EAC Mooring Array
   eacCumulativeTransport: {
@@ -110,6 +123,12 @@ const COMMON_LEGEND_ITEMS = {
     description: 'The latest ASL (NRT00) map is usually dated 4 days behind real time, as indicated.',
   },
 
+  // SWOT - description only (popup only, no sidebar shape)
+  swotSeaSurfaceHeight: {
+    label: 'Sea Surface Height',
+    description: 'contours every 5 cm.',
+  },
+
   // Seal CTD
   ctdProfile: {
     icon: 'dive-point',
@@ -126,6 +145,33 @@ const SST_MAP_LEGENDS: LegendItem[] = [
   COMMON_LEGEND_ITEMS.ship,
   COMMON_LEGEND_ITEMS.fishSoop,
   COMMON_LEGEND_ITEMS.mooring,
+];
+
+// SWOT legend (legacy 97_swot.php getLegend + dr_swot_legend.html legend text).
+// Sidebar shows items with a shape; the popup also shows the description-only
+// isobaths and Sea Surface Height entries.
+const SWOT_LEGENDS: LegendItem[] = [
+  COMMON_LEGEND_ITEMS.argo,
+  COMMON_LEGEND_ITEMS.glider,
+  {
+    ...COMMON_LEGEND_ITEMS.radar,
+    description:
+      'The average velocity using all available hourly radar velocities from the IMOS radar facility within a specified time window around t0. Eg (3-12h avg) indicates a minimum of 3 hourly radar velocity estimates are required within a 12 hour window. Blue (red) vectors are plotted over waters warmer (cooler) than the mean value in the color bar axis.',
+  },
+  {
+    ...COMMON_LEGEND_ITEMS.drifter,
+    description:
+      '6 hourly Global Drifter Program surface drifter (drogued at 15m on deployment) within a window of -2 to +1 day around t0. Location and velocity are indicated with pink arrow heads.',
+  },
+  {
+    ...COMMON_LEGEND_ITEMS.ship,
+    description:
+      'Underway water temperature, plotted hourly, from ships with hull-mounted intake. These include the RV Investigator (MNF), RV Solander and RV Cape Ferguson (AIMS), and the Spirit of Tasmania 2, Sea Flyte and Stadacona from (IMOS Ships of Opportunity Facility). Data within t0 +/- 1day is indicated with a small black dot at the ship location and a black circle indicates the measurement occurred within 12 hours of t0.',
+  },
+  COMMON_LEGEND_ITEMS.adcp,
+  COMMON_LEGEND_ITEMS.fishSoop,
+  COMMON_LEGEND_ITEMS.eacIsobaths,
+  COMMON_LEGEND_ITEMS.swotSeaSurfaceHeight,
 ];
 
 export const productLegends: ProductLegend[] = [
@@ -150,6 +196,14 @@ export const productLegends: ProductLegend[] = [
     childrenLegends: {
       'adjustedSeaLevelAnomaly-sst': null,
       'adjustedSeaLevelAnomaly-nonTidalSla': [...SST_MAP_LEGENDS],
+    },
+  },
+  {
+    id: 'swotGsla',
+    items: null,
+    childrenLegends: {
+      'swotGsla-ssh': [...SWOT_LEGENDS],
+      'swotGsla-mdt': [...SWOT_LEGENDS],
     },
   },
   {
@@ -196,25 +250,3 @@ export const productLegends: ProductLegend[] = [
     ],
   },
 ];
-
-/**
- * Get legend items for a specific product and optionally a child product
- * @param productKey - The main product key
- * @param childKey - Optional child product key
- * @returns Array of legend items or null if not found
- */
-export const getProductLegend = (productKey: RootProductID, childKey?: string): LegendItem[] | null => {
-  const productLegend = productLegends.find((legend) => legend.id === productKey);
-
-  if (!productLegend) {
-    return null;
-  }
-
-  // If child key is provided and has special legend, return that
-  if (childKey && productLegend.childrenLegends && childKey in productLegend.childrenLegends) {
-    return productLegend.childrenLegends[childKey];
-  }
-
-  // Otherwise return parent product's legend items
-  return productLegend.items;
-};

--- a/src/hooks/useDateNavigation/useDateNavigation.ts
+++ b/src/hooks/useDateNavigation/useDateNavigation.ts
@@ -263,9 +263,15 @@ export const useDateListNavigation = ({
     // Parse date parameter (pure — no side effects)
     const result = parseDateParamForList(dateParam, dateFormat, dates, productId);
 
-    // Return parsed date or fallback to first available date or today
+    // Defer syncing the resolved date to the URL until the real list loads — until then
+    // the navigator runs on a synthetic fallback list and the store's default productId
+    // (`sixDaySst-sst`, DAY format), which would rewrite an HOUR date to DAY. `currentDate`
+    // is still returned for display. Mirrors the latest-date branch above.
     if (result.date && result.date.isValid()) {
-      return { currentDate: result.date, resolvedDateParam: result.resolvedDateParam };
+      return {
+        currentDate: result.date,
+        resolvedDateParam: isDateListLoading ? null : result.resolvedDateParam,
+      };
     }
 
     return {

--- a/src/utils/product-utils/product.test.ts
+++ b/src/utils/product-utils/product.test.ts
@@ -1,6 +1,6 @@
 import { vi, describe, it, expect } from 'vitest';
 import { OC_PRODUCTS } from '@/constants/product';
-import { AnyProductID } from '@/types/product';
+import { AnyProductID, ProductID } from '@/types/product';
 import {
   findFlatProductById,
   getProductByKey,
@@ -188,7 +188,7 @@ describe('getProductLegend', () => {
       'Sea Surface Height',
     ];
 
-    it.each(['swotGsla-ssh', 'swotGsla-mdt'])('provides the SWOT legend for %s', (childKey) => {
+    it.each(['swotGsla-ssh', 'swotGsla-mdt'] as ProductID[])('provides the SWOT legend for %s', (childKey) => {
       const items = getProductLegend('swotGsla', childKey);
 
       expect(items).not.toBeNull();

--- a/src/utils/product-utils/product.test.ts
+++ b/src/utils/product-utils/product.test.ts
@@ -8,6 +8,7 @@ import {
   checkProductHasSubProduct,
   getProductFullPathById,
   getProductPathWithSubProduct,
+  getProductLegend,
 } from './product';
 
 vi.mock('@/constants/product', () => ({
@@ -160,5 +161,60 @@ describe('getProductPathWithSubProduct', () => {
     expect(() => getProductPathWithSubProduct('nonExistentProduct' as unknown as AnyProductID)).toThrow(
       'Product with id nonExistentProduct not found',
     );
+  });
+});
+
+describe('getProductLegend', () => {
+  it('returns null for an unknown product', () => {
+    // @ts-expect-error - intentionally passing an invalid product id
+    expect(getProductLegend('notAProduct')).toBeNull();
+  });
+
+  it('returns the parent items (null) when no matching child legend is given', () => {
+    // swotGsla only defines child legends, so the parent fallback is null
+    expect(getProductLegend('swotGsla')).toBeNull();
+  });
+
+  describe('SWOT/GSLA legends', () => {
+    const expectedLabels = [
+      'Argo',
+      'Glider',
+      'Radar',
+      'Drifter',
+      'Ship',
+      'ADCP velocity',
+      'Fish SOOP',
+      'Selected isobaths',
+      'Sea Surface Height',
+    ];
+
+    it.each(['swotGsla-ssh', 'swotGsla-mdt'])('provides the SWOT legend for %s', (childKey) => {
+      const items = getProductLegend('swotGsla', childKey);
+
+      expect(items).not.toBeNull();
+      expect(items?.map((item) => item.label)).toEqual(expectedLabels);
+    });
+
+    it('uses the same legend for SSH and MDT', () => {
+      expect(getProductLegend('swotGsla', 'swotGsla-ssh')).toEqual(getProductLegend('swotGsla', 'swotGsla-mdt'));
+    });
+
+    it('includes the ADCP velocity item with a sidebar shape and description', () => {
+      const items = getProductLegend('swotGsla', 'swotGsla-ssh');
+      const adcp = items?.find((item) => item.label === 'ADCP velocity');
+
+      expect(adcp?.shape).toBeDefined();
+      expect(adcp?.description).toMatch(/Acoustic Doppler Current Profilers/);
+    });
+
+    it('includes popup-only entries (isobaths and Sea Surface Height) without a shape', () => {
+      const items = getProductLegend('swotGsla', 'swotGsla-ssh');
+      const isobaths = items?.find((item) => item.label === 'Selected isobaths');
+      const ssh = items?.find((item) => item.label === 'Sea Surface Height');
+
+      expect(isobaths?.shape).toBeUndefined();
+      expect(ssh?.shape).toBeUndefined();
+      expect(ssh?.description).toBe('contours every 5 cm.');
+    });
   });
 });

--- a/src/utils/product-utils/product.ts
+++ b/src/utils/product-utils/product.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_SUB_PRODUCT_ROUTES } from '@/configs/products/default-routes';
 import { OC_PRODUCTS } from '@/constants/product';
+import { productLegends, LegendItem } from '@/constants/productLegends';
 import { flattenedProducts, flattenedLeafProducts } from '@/data/productData';
 import {
   AnyProductID,
@@ -210,6 +211,26 @@ const getTargetProductIdAfterRouting = (rootProductId: RootProductID): ProductID
   return mainProduct.key as ProductID;
 };
 
+/**
+ * Get legend items for a specific product and optionally a child product
+ * @param productKey - The main product key
+ * @param childKey - Optional child product key
+ * @returns Array of legend items or null if not found
+ */
+const getProductLegend = (productKey: RootProductID, childKey?: string): LegendItem[] | null => {
+  const productLegend = productLegends.find((legend) => legend.id === productKey);
+
+  if (!productLegend) {
+    return null;
+  }
+
+  if (childKey && productLegend.childrenLegends && childKey in productLegend.childrenLegends) {
+    return productLegend.childrenLegends[childKey];
+  }
+
+  return productLegend.items;
+};
+
 export {
   combineProducts,
   combinedProducts,
@@ -225,4 +246,5 @@ export {
   getProductFullPathById,
   getProductPathWithSubProduct,
   getTargetProductIdAfterRouting,
+  getProductLegend,
 };

--- a/src/utils/product-utils/product.ts
+++ b/src/utils/product-utils/product.ts
@@ -215,9 +215,10 @@ const getTargetProductIdAfterRouting = (rootProductId: RootProductID): ProductID
  * Get legend items for a specific product and optionally a child product
  * @param productKey - The main product key
  * @param childKey - Optional child product key
- * @returns Array of legend items or null if not found
+ * @returns Array of legend items, or null when the product is not found or
+ *          its (parent or child) legend is explicitly null
  */
-const getProductLegend = (productKey: RootProductID, childKey?: string): LegendItem[] | null => {
+const getProductLegend = (productKey: RootProductID, childKey?: ProductID): LegendItem[] | null => {
   const productLegend = productLegends.find((legend) => legend.id === productKey);
 
   if (!productLegend) {


### PR DESCRIPTION
Mirror the legacy SWOT legend (incl. ADCP and popup-only isobaths and Sea Surface Height) and show the product name as the legend popup title. Move getProductLegend into product-utils so the constants file stays data-only.