### PR TITLE
✨ extract FishSOOP Average Anomalies into standalone sub-product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
 tmp/
+.notes/
 
 .pnp.*
 .yarn/*

--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -44,8 +44,9 @@ const ProductSideBar: React.FC = () => {
   const { mainProduct, subProduct, subProducts } = useProductConvert();
   const { updateQueryParamsAndNavigate, getQueryParamsByKey } = useQueryParams();
   const useDate = useDateStore((state) => state.date);
-  const { isArgo, isCurrentMeters, isSealCtd, isSurfaceWaves, isFishSoop } = useProductCheck();
-  const shouldRenderMiniMap = useShowProductOverMap();
+  const { isArgo, isCurrentMeters, isSealCtd, isSurfaceWaves, isFishSoop, isFishSoopAverageAnomalies } =
+    useProductCheck();
+  const shouldRenderMiniMap = useShowProductOverMap() && !isFishSoopAverageAnomalies;
 
   const mooredInstrumentArrayPath = useMemo(() => {
     return (

--- a/src/components/DataVisualisationSidebar/ProductSidebar.tsx
+++ b/src/components/DataVisualisationSidebar/ProductSidebar.tsx
@@ -25,7 +25,6 @@ import useProductCheck from '@/stores/product-store/hooks/useProductCheck';
 import { useShowProductOverMap } from '@/stores/product-store/hooks/useShowProductOverMap';
 import { useQueryParams } from '@/hooks';
 import { findLeafFlatProductById, getProductLegend } from '@/utils/product-utils/product';
-import { FISHSOOP_AVERAGE_REGION_ID } from '@/constants/fishSoop';
 import { DEFAULT_SUB_PRODUCT_ROUTES } from '@/configs/products/default-routes';
 import Legend from './components/Legend';
 import MiniMap from './components/MiniMap';
@@ -116,24 +115,16 @@ const ProductSideBar: React.FC = () => {
     }
 
     // Drop params that don't apply to the target FishSOOP sub-product: profiles
-    // is date-driven (no quarter/layer/page and no 'avg' pseudo region), while
-    // the anomaly sub-products have no date axis.
+    // is date-driven; the region-based anomaly products have no date axis; the
+    // average overview has neither date nor region/quarter/layer (page only).
     if (isFishSoop) {
-      const currentRegion = getQueryParamsByKey('region');
-      updateParam =
-        key === 'fishSOOP-profiles'
-          ? {
-              quarter: null,
-              layer: null,
-              page: null,
-              ...(currentRegion === FISHSOOP_AVERAGE_REGION_ID ? { region: null } : {}),
-            }
-          : {
-              date: null,
-              quarter: null,
-              page: null,
-              ...(currentRegion === FISHSOOP_AVERAGE_REGION_ID ? { region: null } : {}),
-            };
+      if (key === 'fishSOOP-profiles') {
+        updateParam = { quarter: null, layer: null, page: null };
+      } else if (key === 'fishSOOP-averageAnomalies') {
+        updateParam = { date: null, quarter: null, layer: null, region: null };
+      } else {
+        updateParam = { date: null, page: null };
+      }
     }
 
     if (isSealCtd) {

--- a/src/components/DataVisualisationSidebar/components/FishSoopFilters.tsx
+++ b/src/components/DataVisualisationSidebar/components/FishSoopFilters.tsx
@@ -1,21 +1,15 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
-import { Button, Dropdown } from '@/components/Shared';
+import { Dropdown } from '@/components/Shared';
 import { ProductSidebarText } from '@/constants/textConstant';
 import useFishSoopStore, {
   setFishSoopRegion,
   setFishSoopQuarter,
   setFishSoopLayer,
   setFishSoopAvgPage,
-  setFishSoopMode,
 } from '@/stores/fish-soop-store/fishSoop';
 import { useFishSoopAnomalyImageList } from '@/services/hooks';
-import {
-  FISHSOOP_AVERAGE_REGION_ID,
-  FISHSOOP_AVERAGE_REGION_LABEL,
-  FISHSOOP_LAYER_DEPTHS,
-  getFishSoopRegionByCode,
-} from '@/constants/fishSoop';
+import { FISHSOOP_LAYER_DEPTHS, getFishSoopAvgPageLabel, getFishSoopRegionByCode } from '@/constants/fishSoop';
 import { resolveFishSoopAnomaly } from '@/utils/fish-soop-utils/fishSoopAnomaly';
 import { SubProduct } from '@/types/product';
 import omitEmptyParams from '@/hooks/useQueryParams/omitEmptyParams';
@@ -42,50 +36,43 @@ const FishSoopFilters: React.FC<FishSoopFiltersProps> = ({ subProduct }) => {
   const subProductKey = subProduct?.key;
   const isQuarterly = subProductKey === 'fishSOOP-quarterlyAnomalies';
   const isDepth = subProductKey === 'fishSOOP-depthAnomalies';
-  const { region, quarter, layer, avgPage, mode } = useFishSoopStore();
+  const isAverageAnomalies = subProductKey === 'fishSOOP-averageAnomalies';
+  const { region, quarter, layer, avgPage } = useFishSoopStore();
   const [searchParams, setSearchParams] = useSearchParams();
   const { entries, isLoading } = useFishSoopAnomalyImageList(subProductKey ?? 'fishSOOP-profiles');
-
-  const isAverageMode = isQuarterly && mode === 'average';
 
   const resolved = useMemo(
     () =>
       resolveFishSoopAnomaly(entries, {
-        mode: isAverageMode ? 'average' : 'region',
+        mode: isAverageAnomalies ? 'average' : 'region',
         region,
         quarter: isQuarterly ? quarter : '',
         layer,
         avgPage,
       }),
-    [entries, isAverageMode, isQuarterly, region, quarter, layer, avgPage],
+    [entries, isAverageAnomalies, isQuarterly, region, quarter, layer, avgPage],
   );
 
   // update store based on params
   useEffect(() => {
+    if (isAverageAnomalies) {
+      const urlPage = searchParams.get('page');
+      setFishSoopAvgPage(urlPage ?? '');
+      return;
+    }
+
     const urlRegion = searchParams.get('region');
     const urlQuarter = searchParams.get('quarter');
     const urlLayer = searchParams.get('layer');
-    const urlPage = searchParams.get('page');
 
-    // `region=avg` is only meaningful for Quarterly Anomalies; on Depth Anomalies
-    // it must resolve as a normal region so the store mode stays consistent.
-    if (isQuarterly && urlRegion === FISHSOOP_AVERAGE_REGION_ID) {
-      setFishSoopMode('average');
-    } else if (urlRegion && urlRegion !== FISHSOOP_AVERAGE_REGION_ID) {
-      setFishSoopMode('region');
-      setFishSoopRegion(urlRegion);
-    } else {
-      setFishSoopMode('region');
-    }
+    if (urlRegion) setFishSoopRegion(urlRegion);
     if (urlQuarter) setFishSoopQuarter(urlQuarter);
     else setFishSoopQuarter('');
     if (urlLayer) setFishSoopLayer(urlLayer);
     else setFishSoopLayer('');
-    if (urlPage) setFishSoopAvgPage(urlPage);
-    else setFishSoopAvgPage('');
-  }, [searchParams, isQuarterly]);
+  }, [searchParams, isAverageAnomalies]);
 
-  if (!isQuarterly && !isDepth) {
+  if (!isQuarterly && !isDepth && !isAverageAnomalies) {
     return null;
   }
 
@@ -93,10 +80,10 @@ const FishSoopFilters: React.FC<FishSoopFiltersProps> = ({ subProduct }) => {
     return null;
   }
 
-  const regionElements = [
-    ...(isQuarterly ? [{ label: FISHSOOP_AVERAGE_REGION_LABEL, id: FISHSOOP_AVERAGE_REGION_ID }] : []),
-    ...resolved.regionOptions.map((code) => ({ label: getFishSoopRegionByCode(code)?.title ?? code, id: code })),
-  ];
+  const regionElements = resolved.regionOptions.map((code) => ({
+    label: getFishSoopRegionByCode(code)?.title ?? code,
+    id: code,
+  }));
 
   const quarterElements = resolved.quarterOptions.map((id) => ({ label: formatQuarterLabel(id), id }));
 
@@ -105,16 +92,12 @@ const FishSoopFilters: React.FC<FishSoopFiltersProps> = ({ subProduct }) => {
     id: String(layerNo),
   }));
 
+  const pageElements = resolved.avgPageOptions.map((page) => ({
+    label: getFishSoopAvgPageLabel(page),
+    id: String(page),
+  }));
+
   const handleRegionChange = (id: string) => {
-    if (id === FISHSOOP_AVERAGE_REGION_ID) {
-      setFishSoopMode('average');
-      const validPage = resolved.avgPageOptions.includes(Number(avgPage))
-        ? avgPage
-        : String(resolved.avgPageOptions[0] ?? '');
-      setSearchParams(omitEmptyParams({ region: FISHSOOP_AVERAGE_REGION_ID, page: validPage }));
-      return;
-    }
-    setFishSoopMode('region');
     setFishSoopRegion(id);
     setSearchParams(omitEmptyParams({ region: id }));
   };
@@ -129,23 +112,38 @@ const FishSoopFilters: React.FC<FishSoopFiltersProps> = ({ subProduct }) => {
     setSearchParams(omitEmptyParams({ region: resolved.region, quarter: resolved.quarter, layer: id }));
   };
 
-  const handleAvgPageChange = (page: number) => {
-    setFishSoopAvgPage(String(page));
-    setSearchParams(omitEmptyParams({ region: FISHSOOP_AVERAGE_REGION_ID, page: String(page) }));
+  const handleAvgPageChange = (id: string) => {
+    setFishSoopAvgPage(id);
+    setSearchParams(omitEmptyParams({ page: id }));
   };
+
+  if (isAverageAnomalies) {
+    return (
+      <div className="text-imos-dark-grey *:border-imos-light-blue text-base *:border-b-1 *:px-4 *:pb-4 [&>*:last-child]:border-b-0">
+        <FilterSection title={ProductSidebarText.PAGE}>
+          <Dropdown
+            elements={pageElements}
+            selectedId={String(resolved.avgPage ?? '')}
+            onChange={(elem) => handleAvgPageChange(elem.id)}
+            smallDropdown
+          />
+        </FilterSection>
+      </div>
+    );
+  }
 
   return (
     <div className="text-imos-dark-grey *:border-imos-light-blue text-base *:border-b-1 *:px-4 *:pb-4 [&>*:last-child]:border-b-0">
       <FilterSection title={ProductSidebarText.REGION}>
         <Dropdown
           elements={regionElements}
-          selectedId={isAverageMode ? FISHSOOP_AVERAGE_REGION_ID : resolved.region}
+          selectedId={resolved.region}
           onChange={(elem) => handleRegionChange(elem.id)}
           smallDropdown
         />
       </FilterSection>
 
-      {isQuarterly && !isAverageMode && (
+      {isQuarterly && (
         <FilterSection title={ProductSidebarText.QUARTER}>
           <Dropdown
             elements={quarterElements}
@@ -156,36 +154,14 @@ const FishSoopFilters: React.FC<FishSoopFiltersProps> = ({ subProduct }) => {
         </FilterSection>
       )}
 
-      {!isAverageMode && (
-        <FilterSection title={ProductSidebarText.DEPTH_LAYER}>
-          <Dropdown
-            elements={layerElements}
-            selectedId={String(resolved.layer ?? '')}
-            onChange={(elem) => handleLayerChange(elem.id)}
-            smallDropdown
-          />
-        </FilterSection>
-      )}
-
-      {isAverageMode && (
-        <div>
-          <h3 className="ml-3 py-2">{ProductSidebarText.PAGE}</h3>
-          <div className="mt-2 mb-6 flex flex-wrap justify-between gap-2">
-            {resolved.avgPageOptions.map((page) => (
-              <div key={page} className="flex-1">
-                <Button
-                  size="full"
-                  borderRadius="small"
-                  type={resolved.avgPage === page ? 'primary' : 'secondary'}
-                  onClick={() => handleAvgPageChange(page)}
-                >
-                  {`p${page}`}
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <FilterSection title={ProductSidebarText.DEPTH_LAYER}>
+        <Dropdown
+          elements={layerElements}
+          selectedId={String(resolved.layer ?? '')}
+          onChange={(elem) => handleLayerChange(elem.id)}
+          smallDropdown
+        />
+      </FilterSection>
     </div>
   );
 };

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
@@ -2255,7 +2255,7 @@ const FishSoopAverageAnomaliesModalData = () => {
       <p className="mb-2">
         We say &apos;potentially&apos; because there are several possible reasons why no coherent pattern might emerge:
         1) insufficient numbers of observations (relative to the real changes that have occurred), 2) artefacts in CARS
-        (due to sparsity of the data base used and/or interpolation artefacts), and 3) measurement errors (undetected by
+        (due to sparsity of the database used and/or interpolation artefacts), and 3) measurement errors (undetected by
         quality control procedures).
       </p>
       <p className="mb-2">Three-monthly, regional, layer-averages of the differences.</p>

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData.tsx
@@ -2236,6 +2236,33 @@ const FishSoopDepthAnomaliesModalData = () => {
   );
 };
 
+const FishSoopAverageAnomaliesModalData = () => {
+  return (
+    <div className="p-4 text-gray-800">
+      <h3 className="mb-2 font-semibold">FishSOOP temperatures compared to historical observations</h3>
+      <p className="mb-2">
+        In this section we compare the FishSOOP data set with the CARS2009 climatology in order to see if the FishSOOP
+        observations differ from CARS2009 in any systematic way(s). Is there a pattern or does profile-to-profile
+        variability look like random noise, suggesting the ocean is so under-sampled that no patterns are yet to emerge?
+      </p>
+      <p className="mb-2">
+        But first: why look at the differences from CARS? Because we know that the temperature of the ocean varies
+        strongly with depth, time and location and that the CARS seasonal climatology accounts for much of this. The
+        FishSOOP observations, which are very unevenly distributed in depth-time-location space, are therefore
+        inevitably aliased. Subtracting the CARS counterparts of the observations removes much of this aliased signal,
+        potentially allowing coherent patterns of change to emerge.
+      </p>
+      <p className="mb-2">
+        We say &apos;potentially&apos; because there are several possible reasons why no coherent pattern might emerge:
+        1) insufficient numbers of observations (relative to the real changes that have occurred), 2) artefacts in CARS
+        (due to sparsity of the data base used and/or interpolation artefacts), and 3) measurement errors (undetected by
+        quality control procedures).
+      </p>
+      <p className="mb-2">Three-monthly, regional, layer-averages of the differences.</p>
+    </div>
+  );
+};
+
 export {
   OceanColourModalData,
   SixDaySstModalData,
@@ -2251,5 +2278,6 @@ export {
   FishSoopModalData,
   FishSoopProfilesModalData,
   FishSoopQuarterlyAnomaliesModalData,
+  FishSoopAverageAnomaliesModalData,
   FishSoopDepthAnomaliesModalData,
 };

--- a/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductSummaryList.tsx
+++ b/src/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductSummaryList.tsx
@@ -13,6 +13,7 @@ import {
   FishSoopModalData,
   FishSoopProfilesModalData,
   FishSoopQuarterlyAnomaliesModalData,
+  FishSoopAverageAnomaliesModalData,
   FishSoopDepthAnomaliesModalData,
 } from '@/components/DataVisualisationSidebar/components/ProductDescriptionModal/ProductDescriptionData';
 import {
@@ -153,6 +154,12 @@ export const productInfoList: ProductInfo[] = [
         summary:
           '3-month averages of the whole FishSOOP dataset compared with a historical climatology reveal how the ocean has changed. Click for more depth layers. The plots also show the data coverage history.',
         description: FishSoopQuarterlyAnomaliesModalData,
+      },
+      'fishSOOP-averageAnomalies': {
+        title: 'Average Anomalies',
+        summary:
+          'Whole-dataset, three-monthly regional layer-averages of FishSOOP temperatures compared with the CARS2009 climatology, to reveal whether the observations differ systematically from the historical record.',
+        description: FishSoopAverageAnomaliesModalData,
       },
       'fishSOOP-depthAnomalies': {
         title: 'Depth Anomalies',

--- a/src/components/ProductMenuBar/ProductMenuBar.tsx
+++ b/src/components/ProductMenuBar/ProductMenuBar.tsx
@@ -169,7 +169,9 @@ const ProductMenuBar: React.FC<ProductMenuBarProps> = ({
 
   return (
     <div className="mb-2 w-full bg-white p-2 md:rounded-md md:bg-transparent md:p-0">
-      <div className="my-2 flex h-11 items-center justify-center md:hidden">
+      <div
+        className={`my-2 h-11 items-center justify-center md:hidden ${isFishSoopAverageAnomalies ? 'hidden' : 'flex'}`}
+      >
         <Button
           onClick={handleToggleMap}
           borderRadius="extraSmall"

--- a/src/components/ProductMenuBar/ProductMenuBar.tsx
+++ b/src/components/ProductMenuBar/ProductMenuBar.tsx
@@ -49,6 +49,7 @@ const ProductMenuBar: React.FC<ProductMenuBarProps> = ({
     isSwotGslaMdt,
     isFishSoop,
     isFishSoopAnomaly,
+    isFishSoopAverageAnomalies,
   } = useProductCheck();
   const { isArgoValid } = useArgoProductValidQueryParams();
   const productId = useProductStore((state) => state.productParams.productId);
@@ -182,7 +183,7 @@ const ProductMenuBar: React.FC<ProductMenuBarProps> = ({
         </Button>
       </div>
       <div className="font-open-sans text-imos-dark-grey flex w-full flex-wrap items-center gap-2 font-medium md:mb-2 md:gap-3">
-        {!isSwotGslaMdt && !isFishSoopAnomaly && (
+        {!isSwotGslaMdt && !isFishSoopAnomaly && !isFishSoopAverageAnomalies && (
           <>
             <div className="border-imos-calypso-blue/50 flex h-11 grow basis-[calc(100%-4rem)] items-center justify-between rounded-md border bg-white md:grow md:basis-auto md:border-none">
               {isCurrentMeters ? (

--- a/src/configs/products/data-source.ts
+++ b/src/configs/products/data-source.ts
@@ -35,6 +35,7 @@ export const API_IMAGE_LIST_ENABLED_PRODUCTS: ProductID[] = [
   'argo',
   'fishSOOP-profiles',
   'fishSOOP-quarterlyAnomalies',
+  'fishSOOP-averageAnomalies',
   'fishSOOP-depthAnomalies',
 ];
 
@@ -49,6 +50,7 @@ export const API_LATEST_DATES_DISABLED_PRODUCTS: ProductID[] = [
   'sixDaySst-climatology',
   'sixDaySst-climatologyDataCount',
   'fishSOOP-quarterlyAnomalies',
+  'fishSOOP-averageAnomalies',
   'fishSOOP-depthAnomalies',
 ];
 
@@ -65,6 +67,7 @@ export const FIXED_IMAGE_LIST_PRODUCTS: ProductID[] = [
   // Region-less FishSOOP anomaly products: their image lists are fetched without a
   // region param via useFishSoopAnomalyImageList, not the generic date-list query.
   'fishSOOP-quarterlyAnomalies',
+  'fishSOOP-averageAnomalies',
   'fishSOOP-depthAnomalies',
 ];
 

--- a/src/constants/fishSoop.ts
+++ b/src/constants/fishSoop.ts
@@ -39,9 +39,13 @@ export const FISHSOOP_LAYER_DEPTHS: Record<number, string> = {
   8: '0–1000 m',
 };
 
-/** Pseudo region id for the "Average (whole dataset)" entry in the Quarterly Anomalies region dropdown. */
-export const FISHSOOP_AVERAGE_REGION_ID = 'avg';
-export const FISHSOOP_AVERAGE_REGION_LABEL = 'Average (whole dataset)';
+/**
+ * Each average-overview page (`tanom_avg_p<N>.gif`) stacks two depth layers:
+ * page N shows layer 2N-1 (top) and layer 2N (bottom). Derives a readable depth-range
+ * label from the shared layer bands so the page selector reads like the depth-layer one.
+ */
+export const getFishSoopAvgPageLabel = (page: number): string =>
+  [FISHSOOP_LAYER_DEPTHS[page * 2 - 1], FISHSOOP_LAYER_DEPTHS[page * 2]].filter(Boolean).join(', ');
 
 /** Date of the earliest finder map GIF on the file server (`fishsoop/maps/2021/20211120.gif`). */
 // TODO: Eventually this should be replaced with an API call that lists available dates, but for now hardcode the known start date of the finder maps to avoid offering date options that have no data.

--- a/src/constants/fishSoop.ts
+++ b/src/constants/fishSoop.ts
@@ -44,8 +44,10 @@ export const FISHSOOP_LAYER_DEPTHS: Record<number, string> = {
  * page N shows layer 2N-1 (top) and layer 2N (bottom). Derives a readable depth-range
  * label from the shared layer bands so the page selector reads like the depth-layer one.
  */
-export const getFishSoopAvgPageLabel = (page: number): string =>
-  [FISHSOOP_LAYER_DEPTHS[page * 2 - 1], FISHSOOP_LAYER_DEPTHS[page * 2]].filter(Boolean).join(', ');
+export const getFishSoopAvgPageLabel = (page: number): string => {
+  const label = [FISHSOOP_LAYER_DEPTHS[page * 2 - 1], FISHSOOP_LAYER_DEPTHS[page * 2]].filter(Boolean).join(', ');
+  return label || `p${page}`;
+};
 
 /** Date of the earliest finder map GIF on the file server (`fishsoop/maps/2021/20211120.gif`). */
 // TODO: Eventually this should be replaced with an API call that lists available dates, but for now hardcode the known start date of the finder maps to avoid offering date options that have no data.

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -609,6 +609,16 @@ export const OC_PRODUCTS: Product[] = [
         },
       },
       {
+        title: 'Average Anomalies',
+        key: 'fishSOOP-averageAnomalies',
+        path: 'average-anomalies',
+        imgPath: null,
+        dateFormat: {
+          localFormat: null,
+          stateFormat: null,
+        },
+      },
+      {
         title: 'Depth Anomalies',
         key: 'fishSOOP-depthAnomalies',
         path: 'depth-anomalies',

--- a/src/pages/AboutView/AboutData.tsx
+++ b/src/pages/AboutView/AboutData.tsx
@@ -1453,7 +1453,7 @@ const FishSoopAboutData = () => {
 
         <h3 className="text-base font-semibold">Three-monthly, regional, layer-averages of the differences</h3>
         <a
-          href="/product/fish-soop/quarterly-anomalies?region=avg&page=1"
+          href="/product/fish-soop/average-anomalies?page=1"
           target="_blank"
           rel="noreferrer noopener"
           className="mx-auto block max-w-xl"

--- a/src/pages/DataView/product-content/ProductContent.tsx
+++ b/src/pages/DataView/product-content/ProductContent.tsx
@@ -74,6 +74,7 @@ const ProductContent: React.FC = () => {
     isSurfaceWavesBuoyTimeseries,
     isFishSoopProfiles,
     isFishSoopAnomaly,
+    isFishSoopAverageAnomalies,
   } = productChecks;
 
   // Determine if we should render with argo tags
@@ -90,16 +91,16 @@ const ProductContent: React.FC = () => {
   // Resolve the FishSOOP anomaly selection (region/quarter/layer or average page)
   // back to the exact entry in the parsed image list
   const fishSoopAnomalyResolved = useMemo(() => {
-    if (!isFishSoopAnomaly) return null;
+    if (!isFishSoopAnomaly && !isFishSoopAverageAnomalies) return null;
     const isQuarterly = useProductId === 'fishSOOP-quarterlyAnomalies';
     return resolveFishSoopAnomaly(fishSoopAnomalyEntries, {
-      mode: isQuarterly && fishSoopParams.mode === 'average' ? 'average' : 'region',
+      mode: isFishSoopAverageAnomalies ? 'average' : 'region',
       region: fishSoopParams.region,
       quarter: isQuarterly ? fishSoopParams.quarter : '',
       layer: fishSoopParams.layer,
       avgPage: fishSoopParams.avgPage,
     });
-  }, [isFishSoopAnomaly, useProductId, fishSoopAnomalyEntries, fishSoopParams]);
+  }, [isFishSoopAnomaly, isFishSoopAverageAnomalies, useProductId, fishSoopAnomalyEntries, fishSoopParams]);
 
   // Fetch Argo profile cycles — shares cache with useDateList and WmoSection via the same query key
   const { data: argoProfileCyclesData } = useQuery({
@@ -133,7 +134,7 @@ const ProductContent: React.FC = () => {
           return buildSealCtdTagsDataImageUrl(urlParams.sealCtdTag!, useDate, useProductId);
         case useProductId === 'surfaceWaves-buoyTimeseries' && hasSelectedParams.buoyRegion && !!urlParams.buoyRegion:
           return buildSurfaceWavesBuoyTimeseriesImageUrl(urlParams.buoyRegion!, useDate);
-        case isFishSoopAnomaly:
+        case isFishSoopAnomaly || isFishSoopAverageAnomalies:
           return fishSoopAnomalyResolved?.entry
             ? buildFishSoopAnomalyImageUrl(fishSoopAnomalyResolved.entry)
             : undefined;
@@ -162,6 +163,7 @@ const ProductContent: React.FC = () => {
     isSealCtd,
     isSealCtdTags,
     isFishSoopAnomaly,
+    isFishSoopAverageAnomalies,
     fishSoopAnomalyResolved,
     useProductId,
     useDate,
@@ -237,7 +239,7 @@ const ProductContent: React.FC = () => {
   }
 
   // FishSOOP anomalies: wait for the image list, then require a matching entry
-  if (isFishSoopAnomaly) {
+  if (isFishSoopAnomaly || isFishSoopAverageAnomalies) {
     if (isFishSoopAnomalyListLoading) {
       return <Loading />;
     }

--- a/src/services/hooks/useFishSoopAnomalyImageList.ts
+++ b/src/services/hooks/useFishSoopAnomalyImageList.ts
@@ -5,14 +5,23 @@ import { fetchImageListByProductId } from '@/services/imageList';
 import { sharedQueryConfig } from '@/configs/query';
 import { parseFishSoopAnomalyImageList, FishSoopAnomalyEntry } from '@/utils/fish-soop-utils/fishSoopAnomaly';
 
-const FISHSOOP_ANOMALY_PRODUCTS: ProductID[] = ['fishSOOP-quarterlyAnomalies', 'fishSOOP-depthAnomalies'];
+const FISHSOOP_ANOMALY_PRODUCTS: ProductID[] = [
+  'fishSOOP-quarterlyAnomalies',
+  'fishSOOP-averageAnomalies',
+  'fishSOOP-depthAnomalies',
+];
 
 const useFishSoopAnomalyImageList = (productId: ProductID) => {
   const enabled = FISHSOOP_ANOMALY_PRODUCTS.includes(productId);
 
+  // The Average Anomalies overview reuses the quarterly `anom2/` list, which holds
+  // the `tanom_avg_p<N>.gif` entries; sharing the query key reuses the cache.
+  const fetchProductId: ProductID =
+    productId === 'fishSOOP-averageAnomalies' ? 'fishSOOP-quarterlyAnomalies' : productId;
+
   const { data, isLoading } = useQuery({
-    queryKey: ['fishSoopAnomalyImageList', productId],
-    queryFn: () => fetchImageListByProductId(productId),
+    queryKey: ['fishSoopAnomalyImageList', fetchProductId],
+    queryFn: () => fetchImageListByProductId(fetchProductId),
     enabled,
     ...sharedQueryConfig,
   });

--- a/src/stores/fish-soop-store/fishSoop.ts
+++ b/src/stores/fish-soop-store/fishSoop.ts
@@ -7,7 +7,6 @@ const initialState: FishSoopStoreState = {
   quarter: '',
   layer: '',
   avgPage: '1',
-  mode: 'region',
 };
 
 const useFishSoopStore = create<FishSoopStoreState & FishSoopStoreActions>()(
@@ -19,7 +18,6 @@ const useFishSoopStore = create<FishSoopStoreState & FishSoopStoreActions>()(
         setQuarter: (quarter) => set({ quarter }, false, 'setQuarter'),
         setLayer: (layer) => set({ layer }, false, 'setLayer'),
         setAvgPage: (avgPage) => set({ avgPage }, false, 'setAvgPage'),
-        setMode: (mode) => set({ mode }, false, 'setMode'),
         reset: () => set(initialState, false, 'resetFishSoopStore'),
       },
     }),
@@ -32,7 +30,6 @@ export const {
   setQuarter: setFishSoopQuarter,
   setLayer: setFishSoopLayer,
   setAvgPage: setFishSoopAvgPage,
-  setMode: setFishSoopMode,
   reset: resetFishSoopStore,
 } = useFishSoopStore.getState().actions;
 

--- a/src/stores/fish-soop-store/fishSoop.types.ts
+++ b/src/stores/fish-soop-store/fishSoop.types.ts
@@ -1,5 +1,3 @@
-export type FishSoopMode = 'region' | 'average';
-
 export type FishSoopStoreState = {
   /** FishSOOP region code (e.g. 'TasE'); applies to the anomaly products. */
   region: string;
@@ -9,8 +7,6 @@ export type FishSoopStoreState = {
   layer: string;
   /** Page of the `tanom_avg_p<N>` whole-dataset overview ('1'–'4'). */
   avgPage: string;
-  /** 'average' shows the whole-dataset overview pager instead of quarter/layer. */
-  mode: FishSoopMode;
 };
 
 export type FishSoopStoreActions = {
@@ -19,7 +15,6 @@ export type FishSoopStoreActions = {
     setQuarter: (quarter: string) => void;
     setLayer: (layer: string) => void;
     setAvgPage: (avgPage: string) => void;
-    setMode: (mode: FishSoopMode) => void;
     reset: () => void;
   };
 };

--- a/src/stores/product-store/hooks/useProductCheck.ts
+++ b/src/stores/product-store/hooks/useProductCheck.ts
@@ -32,6 +32,9 @@ const useProductCheck = () => {
   // is region-less (region selection is handled by the sidebar filters)
   const isFishSoopAnomaly =
     subProduct?.key === 'fishSOOP-quarterlyAnomalies' || subProduct?.key === 'fishSOOP-depthAnomalies';
+  // Standalone whole-dataset average overview: region-less list, no date axis, no
+  // region map (unlike the region-based anomaly products above).
+  const isFishSoopAverageAnomalies = subProduct?.key === 'fishSOOP-averageAnomalies';
 
   return {
     isRegionRequired,
@@ -53,6 +56,7 @@ const useProductCheck = () => {
     isFishSoop,
     isFishSoopProfiles,
     isFishSoopAnomaly,
+    isFishSoopAverageAnomalies,
   };
 };
 

--- a/src/stores/product-store/hooks/useShowProductOverMap.ts
+++ b/src/stores/product-store/hooks/useShowProductOverMap.ts
@@ -4,7 +4,8 @@ import useProductStore from '../productStore';
 import useProductCheck from './useProductCheck';
 
 export const useShowProductOverMap = (): boolean => {
-  const { isArgo, isSurfaceWavesBuoyTimeseries, isFishSoopProfiles, isFishSoopAnomaly } = useProductCheck();
+  const { isArgo, isSurfaceWavesBuoyTimeseries, isFishSoopProfiles, isFishSoopAnomaly, isFishSoopAverageAnomalies } =
+    useProductCheck();
   const { isArgoValid } = useArgoProductValidQueryParams();
 
   const { getQueryParamsByKey } = useQueryParams();
@@ -21,7 +22,8 @@ export const useShowProductOverMap = (): boolean => {
 
   // FishSOOP anomaly image-list requests are region-less; region/quarter/layer
   // selection is driven by the sidebar filters (which do write the URL params).
-  if (isFishSoopAnomaly) {
+  // The average overview is likewise region-less and renders the resolved image.
+  if (isFishSoopAnomaly || isFishSoopAverageAnomalies) {
     return true;
   }
 

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -70,6 +70,7 @@ export type ChildProductID =
   // FishSOOP children
   | 'fishSOOP-profiles'
   | 'fishSOOP-quarterlyAnomalies'
+  | 'fishSOOP-averageAnomalies'
   | 'fishSOOP-depthAnomalies';
 
 // Combined types
@@ -133,6 +134,7 @@ export const childProductIDs: ChildProductID[] = [
   'swotGsla-mdt',
   'fishSOOP-profiles',
   'fishSOOP-quarterlyAnomalies',
+  'fishSOOP-averageAnomalies',
   'fishSOOP-depthAnomalies',
 ];
 


### PR DESCRIPTION
Lift the "Average (whole dataset)" overview out of the Quarterly Anomalies region dropdown into its own `fishSOOP-averageAnomalies` sub-product (path `average-anomalies`), placed after Quarterly Anomalies in the button row.

The standalone view has no date picker and no region/quarter/layer — only a Page dropdown whose options now read as depth-range bands (derived from FISHSOOP_LAYER_DEPTHS: page N = layers 2N-1, 2N) while still using the page number for the `?page=N` param and the `tanom_avg_p<N>.gif` URL. It reuses the quarterly `anom2/` image list and the existing resolve/builder logic.

Remove the now-dead `region=avg` machinery: the fish-soop store `mode` field, the FISHSOOP_AVERAGE_REGION_ID/_LABEL constants, and the average branches inside Quarterly Anomalies.